### PR TITLE
Fix: não remover os anexos da requisição ao realizar a primeira trans…

### DIFF
--- a/sme_terceirizadas/produto/models.py
+++ b/sme_terceirizadas/produto/models.py
@@ -332,7 +332,7 @@ class ReclamacaoDeProduto(FluxoReclamacaoProduto, TemChaveExterna, CriadoEm, Cri
                 justificativa=justificativa
             )
             for anexo in kwargs.get('anexos', []):
-                arquivo = convert_base64_to_contentfile(anexo.pop('base64'))
+                arquivo = convert_base64_to_contentfile(anexo.get('base64'))
                 AnexoLogSolicitacoesUsuario.objects.create(
                     log=log_transicao,
                     arquivo=arquivo,


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o método de alterar status da reclamação.
 
# Referência do Azure

- 42997

# Tarefas para concluir

- [x] não remover os anexos da requisição ao realizar a primeira transição de status.