### PR TITLE
Fix: devolve lista vazia quando a escola não tem relacionamentos de l…

### DIFF
--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -1804,9 +1804,12 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
     @property
     def _partes_interessadas_codae_autoriza(self):
         escola = self.escola_destino
-        terceirizada = escola.lote.terceirizada
         responsaveis_escola = [vinculo.usuario.email for vinculo in escola.vinculos.filter(ativo=True)]
-        responsaveis_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(ativo=True)]
+        try:
+            terceirizada = escola.lote.terceirizada
+            responsaveis_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(ativo=True)]
+        except AttributeError:
+            responsaveis_terceirizadas = []
         return responsaveis_escola + responsaveis_terceirizadas
 
     @property


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o fluxo de envio de e-mail no momento de Autorizar uma alteração de U.E.
 
# Referência do Azure

- 42100

# Tarefas para concluir

- [x]  corrigir método de partes interessadas no disparo de e-mails ao Autorizar.