### PR TITLE
Feature/54008-GA-visualização-campo-de-informações-na-solicitação-de-inversão-de-cardápio

### DIFF
--- a/sme_terceirizadas/cardapio/api/viewsets.py
+++ b/sme_terceirizadas/cardapio/api/viewsets.py
@@ -298,7 +298,8 @@ class InversaoCardapioViewSet(viewsets.ModelViewSet):
         try:
             user = request.user
             if inversao_cardapio.status == inversao_cardapio.workflow_class.DRE_VALIDADO:
-                inversao_cardapio.codae_autoriza(user=user)
+                inversao_cardapio.codae_autoriza(
+                    user=user, justificativa=justificativa)
             else:
                 inversao_cardapio.codae_autoriza_questionamento(
                     user=user, justificativa=justificativa)


### PR DESCRIPTION
# Proposta

Este PR visa salvar campo de justificativa/informações da codae quando autorizar inversão

# Referência do Azure

- 54008

# Tarefas para concluir

- [x] Salvar campo de justificativa/informações da codae quando autorizar inversão