### PR TITLE
Bugfix/55495-DE-problema-ao-pesquisar-codigo-eol-do-aluno-na-solicitacao-de-dieta-especial

### DIFF
--- a/sme_terceirizadas/eol_servico/api/viewsets.py
+++ b/sme_terceirizadas/eol_servico/api/viewsets.py
@@ -60,7 +60,9 @@ class DadosAlunoEOLViewSet(ViewSet):
                 'nm_pai_aluno': None,
                 'cd_escola': aluno.escola.codigo_eol,
                 'dc_turma_escola': aluno.serie,
-                'dc_tipo_turno': aluno.periodo_escolar.nome
+                # TODO: investigar e tratar AttributeError para aluno.periodo_escolar.nome
+                # ('NoneType' object has no attribute 'nome')
+                # 'dc_tipo_turno': aluno.periodo_escolar.nome
             }
             return Response({'detail': dados})
         except EOLException as e:


### PR DESCRIPTION
# Proposta

Este PR visa ajustar retorno de aluno mesmo que não tenha o dado de periodo_escolar preenchido na solicitação de dieta especial

# Referência do Azure

- 55495

# Tarefas para concluir

- [x]  Retornar aluno mesmo que não tenha o dado de periodo_escolar preenchido