### PR TITLE
Fix: exibir justificativas ao negar solicitação

### DIFF
--- a/sme_terceirizadas/relatorios/templates/bloco_historico_cancelamento.html
+++ b/sme_terceirizadas/relatorios/templates/bloco_historico_cancelamento.html
@@ -20,6 +20,20 @@
                 {{ log.justificativa }}
               </div>
             {% endif %}
+            {% if log.status_evento_explicacao == "CODAE negou" %}
+              <div>{{ log.criado_em }} - CODAE NEGOU</div>
+              <div class="justificativa-cancelamento-escola-dre">
+                Observação:
+                {{ log.justificativa | safe }}
+              </div>
+            {% endif %}
+            {% if log.status_evento_explicacao == "DRE não validou" %}
+              <div>{{ log.criado_em }} - DRE não validou</div>
+              <div class="justificativa-cancelamento-escola-dre">
+                Observação:
+                {{ log.justificativa | safe }}
+              </div>
+            {% endif %}
           {% endfor %}
         </div>
       </div>


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a exibição da justificativa no relatório ao negar uma solicitação com o Perfil CODAE ou DRE.

# Referência do Azure

- 52551

# Tarefas para concluir

- [x]  adicionar justificativa ao negar solicitação para bloco de justificativas do template de relatório de kit lanche.