### PR TITLE
Bugfix/54064-PD-escola-não-consegue-reclamar-de-produto-que-tem-questionamento-pendente-de-reclamação-feita-por-outra-escola

### DIFF
--- a/sme_terceirizadas/produto/api/viewsets.py
+++ b/sme_terceirizadas/produto/api/viewsets.py
@@ -968,7 +968,9 @@ class ProdutoViewSet(viewsets.ModelViewSet):
             HomologacaoProdutoWorkflow.CODAE_HOMOLOGADO,
             HomologacaoProdutoWorkflow.ESCOLA_OU_NUTRICIONISTA_RECLAMOU,
             HomologacaoProdutoWorkflow.CODAE_PEDIU_ANALISE_RECLAMACAO,
-            HomologacaoProdutoWorkflow.TERCEIRIZADA_RESPONDEU_RECLAMACAO
+            HomologacaoProdutoWorkflow.TERCEIRIZADA_RESPONDEU_RECLAMACAO,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_UE,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_NUTRISUPERVISOR
         ]
 
         queryset = self.get_queryset_filtrado(form_data)


### PR DESCRIPTION
# Proposta

Este PR visa ajustar filtro de produtos homologados para que seja possível reclamações de produtos por outras escolas e nutricionista mesmo que gpcodae questione alguma reclamação existente.

# Referência do Azure

- 54064

# Tarefas para concluir

- [x] Adicionar status de questionamentos para filtro de produtos homologados