### PR TITLE
Fix: remover label 'observação' das justificativas do template do relatório

### DIFF
--- a/sme_terceirizadas/relatorios/templates/bloco_historico_cancelamento.html
+++ b/sme_terceirizadas/relatorios/templates/bloco_historico_cancelamento.html
@@ -9,28 +9,24 @@
             {% if log.status_evento_explicacao == "Escola cancelou" %}
               <div>{{ log.criado_em }} - ESCOLA CANCELOU</div>
               <div class="justificativa-cancelamento-escola-dre">
-                Observação do Cancelamento:
                 {{ log.justificativa }}
               </div>
             {% endif %}
             {% if log.status_evento_explicacao == "DRE cancelou" %}
               <div>{{ log.criado_em }} - DRE CANCELOU</div>
               <div class="justificativa-cancelamento-escola-dre">
-                Observação do Cancelamento:
                 {{ log.justificativa }}
               </div>
             {% endif %}
             {% if log.status_evento_explicacao == "CODAE negou" %}
               <div>{{ log.criado_em }} - CODAE NEGOU</div>
               <div class="justificativa-cancelamento-escola-dre">
-                Observação:
                 {{ log.justificativa | safe }}
               </div>
             {% endif %}
             {% if log.status_evento_explicacao == "DRE não validou" %}
               <div>{{ log.criado_em }} - DRE não validou</div>
               <div class="justificativa-cancelamento-escola-dre">
-                Observação:
                 {{ log.justificativa | safe }}
               </div>
             {% endif %}


### PR DESCRIPTION
# Proposta

Este PR visa remover o label 'observação' das justificativas do template do relatório

# Referência do Azure

- 52551

# Tarefas para concluir

- [x]  remover label do relatório