### PR TITLE
Feature/56651 melhoria notificacao marcar como lido pendencia

### DIFF
--- a/sme_terceirizadas/dados_comuns/__tests__/conftest.py
+++ b/sme_terceirizadas/dados_comuns/__tests__/conftest.py
@@ -247,3 +247,31 @@ def notificacao_de_pendencia(usuario_teste_notificacao_autenticado):
         descricao='A guia 0000 precisa ser conferida',
         usuario=user
     )
+
+
+@pytest.fixture
+def notificacao_de_pendencia_com_requisicao(usuario_teste_notificacao_autenticado):
+    distribuidor = mommy.make(
+        'Terceirizada',
+        contatos=[mommy.make('dados_comuns.Contato')],
+        make_m2m=True,
+        nome_fantasia='Alimentos SA'
+    )
+    requisicao = mommy.make(
+        'SolicitacaoRemessa',
+        cnpj='12345678901234',
+        numero_solicitacao='559890',
+        sequencia_envio=1212,
+        quantidade_total_guias=2,
+        distribuidor=distribuidor
+    )
+    user, client = usuario_teste_notificacao_autenticado
+    return mommy.make(
+        'Notificacao',
+        tipo=Notificacao.TIPO_NOTIFICACAO_PENDENCIA,
+        categoria=Notificacao.CATEGORIA_NOTIFICACAO_GUIA_DE_REMESSA,
+        titulo='Conferencia em atraso',
+        descricao='A guia 0000 precisa ser conferida',
+        usuario=user,
+        requisicao=requisicao
+    )

--- a/sme_terceirizadas/dados_comuns/__tests__/test_models.py
+++ b/sme_terceirizadas/dados_comuns/__tests__/test_models.py
@@ -62,3 +62,41 @@ def test_notificar(notificacao):
     assert obj.descricao == 'teste'
     assert obj.usuario == notificacao.usuario
     assert obj.link == '/teste/'
+
+
+def test_resolver_pendencia(notificacao_de_pendencia_com_requisicao):
+    Notificacao.notificar(
+        tipo=Notificacao.TIPO_NOTIFICACAO_PENDENCIA,
+        categoria=Notificacao.CATEGORIA_NOTIFICACAO_GUIA_DE_REMESSA,
+        titulo=f'Hoje tem entrega de alimentos',
+        descricao='teste',
+        usuario=notificacao_de_pendencia_com_requisicao.usuario,
+        link=f'/teste/',
+        requisicao=notificacao_de_pendencia_com_requisicao.requisicao
+    )
+
+    obj = Notificacao.objects.last()
+
+    assert obj.tipo == Notificacao.TIPO_NOTIFICACAO_PENDENCIA
+    assert obj.categoria == Notificacao.CATEGORIA_NOTIFICACAO_GUIA_DE_REMESSA
+    assert obj.titulo == 'Hoje tem entrega de alimentos'
+    assert obj.descricao == 'teste'
+    assert obj.usuario == notificacao_de_pendencia_com_requisicao.usuario
+    assert obj.link == '/teste/'
+    assert obj.requisicao == notificacao_de_pendencia_com_requisicao.requisicao
+    assert obj.resolvido is False
+    assert obj.lido is False
+
+    Notificacao.resolver_pendencia(titulo=obj.titulo, requisicao=notificacao_de_pendencia_com_requisicao.requisicao)
+
+    obj2 = Notificacao.objects.last()
+
+    assert obj2.tipo == Notificacao.TIPO_NOTIFICACAO_PENDENCIA
+    assert obj2.categoria == Notificacao.CATEGORIA_NOTIFICACAO_GUIA_DE_REMESSA
+    assert obj2.titulo == 'Hoje tem entrega de alimentos'
+    assert obj2.descricao == 'teste'
+    assert obj2.usuario == notificacao_de_pendencia_com_requisicao.usuario
+    assert obj2.link == '/teste/'
+    assert obj2.requisicao == notificacao_de_pendencia_com_requisicao.requisicao
+    assert obj2.resolvido is True
+    assert obj2.lido is True

--- a/sme_terceirizadas/dados_comuns/models.py
+++ b/sme_terceirizadas/dados_comuns/models.py
@@ -493,4 +493,4 @@ class Notificacao(models.Model):
             guia=guia,
             resolvido=False
         )
-        pendencias.update(resolvido=True)
+        pendencias.update(resolvido=True, lido=True)


### PR DESCRIPTION
### Este PR:

- Ao resolver uma pendência, automaticamente ela passa a ser marcada como lida;
- Cria testes unitários para garantir a funcionalidade de resolver pendência com a melhoria solicitada;