### PR TITLE
Fix: mensagem de erro ao tentar cadastrar um nome de protocolo existente

### DIFF
--- a/sme_terceirizadas/dieta_especial/api/serializers_create.py
+++ b/sme_terceirizadas/dieta_especial/api/serializers_create.py
@@ -312,7 +312,7 @@ class ProtocoloPadraoDietaEspecialSerializerCreate(serializers.ModelSerializer):
         nome_protocolo = validated_data['nome_protocolo']
         protocolos = ProtocoloPadraoDietaEspecial.objects.all()
         if (nome_protocolo.upper() in [protocolo.nome_protocolo.upper() for protocolo in protocolos]):
-            raise serializers.ValidationError('Protocolo padrão já existe.')
+            raise serializers.ValidationError('Já existe um protocolo padrão com esse nome.')
         validated_data['nome_protocolo'] = nome_protocolo.upper()
         protocolo_padrao = ProtocoloPadraoDietaEspecial.objects.create(**validated_data)
         for substituicao in substituicoes:
@@ -341,7 +341,7 @@ class ProtocoloPadraoDietaEspecialSerializerCreate(serializers.ModelSerializer):
         nome_protocolo = validated_data['nome_protocolo']
         protocolos = ProtocoloPadraoDietaEspecial.objects.all().exclude(uuid=instance.uuid)
         if (nome_protocolo.upper() in [protocolo.nome_protocolo.upper() for protocolo in protocolos]):
-            raise serializers.ValidationError('Protocolo padrão já existe.')
+            raise serializers.ValidationError('Já existe um protocolo padrão com esse nome.')
         validated_data['nome_protocolo'] = nome_protocolo.upper()
         user = None
         request = self.context.get('request')


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a mensagem retornada ao tentar cadastrar ou atualizar um nome de protocolo padrão existente.

# Referência do Azure

- 56262

# Tarefas para concluir

- [x] corrigir mensagem de erro
