### PR TITLE
Feature/57633-DE-alterar-texto-de-email-ao-autorizar-dieta

### DIFF
--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -2197,8 +2197,11 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
                 anexo=anexo.get('arquivo'),
             )
 
-    def _preenche_template_e_envia_email(self, assunto, titulo, user, partes_interessadas):
-        template = 'fluxo_autorizar_negar_cancelar.html'
+    def _preenche_template_e_envia_email(self, assunto, titulo, user, partes_interessadas, eh_codae_autoriza):
+        if eh_codae_autoriza:
+            template = 'fluxo_codae_autoriza_dieta.html'
+        else:
+            template = 'fluxo_autorizar_negar_cancelar.html'
         dados_template = {'titulo': titulo, 'tipo_solicitacao': self.DESCRICAO,
                           'movimentacao_realizada': str(self.status), 'perfil_que_autorizou': user.nome}
         html = render_to_string(template, dados_template)
@@ -2206,7 +2209,7 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
             assunto=assunto,
             corpo='',
             emails=partes_interessadas,
-            template='fluxo_autorizar_negar_cancelar.html',
+            template=template,
             dados_template={'titulo': titulo, 'tipo_solicitacao': self.DESCRICAO,
                             'movimentacao_realizada': str(self.status), 'perfil_que_autorizou': user.nome},
             html=html
@@ -2257,7 +2260,7 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
         self.salvar_log_transicao(status_evento=LogSolicitacoesUsuario.CODAE_NEGOU,
                                   usuario=user)
         self._preenche_template_e_envia_email(assunto, titulo, user,
-                                              self._partes_interessadas_codae_autoriza_ou_nega)
+                                              self._partes_interessadas_codae_autoriza_ou_nega, False)
 
     @xworkflows.after_transition('codae_autoriza')
     def _codae_autoriza_hook(self, *args, **kwargs):
@@ -2273,9 +2276,9 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
             self._envia_email_autorizar(assunto, titulo, user, self._partes_interessadas_codae_autoriza, dieta_origem)
         else:
             assunto = '[SIGPAE] Status de solicitação - #' + self.id_externo
-            titulo = 'Status de solicitação - #' + self.id_externo
+            titulo = 'Status de Solicitação\n' + self.aluno.codigo_eol + ' ' + self.aluno.nome
             self._preenche_template_e_envia_email(assunto, titulo, user,
-                                                  self._partes_interessadas_codae_autoriza_ou_nega)
+                                                  self._partes_interessadas_codae_autoriza_ou_nega, True)
 
     @xworkflows.after_transition('inicia_fluxo_inativacao')
     def _inicia_fluxo_inativacao_hook(self, *args, **kwargs):

--- a/sme_terceirizadas/dados_comuns/templates/email_base.html
+++ b/sme_terceirizadas/dados_comuns/templates/email_base.html
@@ -27,7 +27,7 @@
               <tr>
                 <td style="color: #0C6B45; text-align: center; font-family: Roboto, sans-serif; line-height: 28px; font-size: 24px">
                   <!-- Titulo do E-mail -->
-                  <b>{{ titulo }}</b>
+                  <b>{{ titulo|linebreaksbr }}</b>
                 </td>
               </tr>
               <tr>

--- a/sme_terceirizadas/dados_comuns/templates/fluxo_codae_autoriza_dieta.html
+++ b/sme_terceirizadas/dados_comuns/templates/fluxo_codae_autoriza_dieta.html
@@ -1,0 +1,8 @@
+{% extends 'email_base.html' %}
+{% load email_templatetags %}
+
+{% block conteudo %}
+  <p>A solicitação de dieta especial foi <strong>AUTORIZADA</strong>.</p>
+  <p>Para acompanhar e visualizar todos os detalhes da solicitação, acesse o sistema.</p>
+  <br/>
+{% endblock %}


### PR DESCRIPTION
# Proposta

Este PR visa alterar texto de email ao autorizar dieta

# Referência do Azure

- 57633

# Tarefas para concluir

- [x] criar template para email de autorizar dieta
- [x] ajustar template base para permitir linebreak no título
- [x] ajustar título e escolha do template para envio de email do fluxo de dieta