### PR TITLE
Feature/57630-GA-retirar-merenda-seca-alteração-alimentação-escola-cei

### DIFF
--- a/sme_terceirizadas/cardapio/api/viewsets.py
+++ b/sme_terceirizadas/cardapio/api/viewsets.py
@@ -928,6 +928,12 @@ class MotivosAlteracaoCardapioViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = MotivoAlteracaoCardapio.objects.all()
     serializer_class = MotivoAlteracaoCardapioSerializer
 
+    def get_queryset(self):
+        user = self.request.user
+        if user.vinculo_atual.perfil.nome in ['DIRETOR CEI']:
+            return MotivoAlteracaoCardapio.objects.exclude(nome__icontains='Merenda Seca')
+        return MotivoAlteracaoCardapio.objects.all()
+
 
 class MotivosSuspensaoCardapioViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_field = 'uuid'


### PR DESCRIPTION
# Proposta

Este PR visa excluir merenda seca do queryset de MotivoAlteracaoCardapio para perfil CEI

# Referência do Azure

- 57630

# Tarefas para concluir

- [x] excluir merenda seca do queryset de MotivoAlteracaoCardapio para perfil CEI