### PR TITLE
Fix: omitir solicitações de cancelamento autorizada

### DIFF
--- a/sme_terceirizadas/paineis_consolidados/models.py
+++ b/sme_terceirizadas/paineis_consolidados/models.py
@@ -426,21 +426,13 @@ class SolicitacoesCODAE(MoldeConsolidado):
 
     @classmethod
     def get_autorizados_dieta_especial(cls, **kwargs):
-        solicitacoes_de_cancelamento = cls.objects.filter(
-            tipo_solicitacao_dieta='CANCELAMENTO_DIETA',
-            status_atual=PedidoAPartirDaEscolaWorkflow.ESCOLA_CANCELOU
-        )
-
-        solicitacoes_em_vigencia_e_ativas = cls.objects.filter(
+        return cls.objects.filter(
             Q(em_vigencia=True) | Q(em_vigencia__isnull=True),
             status_atual__in=cls.AUTORIZADO_STATUS_DIETA_ESPECIAL,
             status_evento__in=cls.AUTORIZADO_EVENTO_DIETA_ESPECIAL,
             tipo_doc=cls.TP_SOL_DIETA_ESPECIAL,
             ativo=True
-        )
-
-        solicitacoes = solicitacoes_de_cancelamento | solicitacoes_em_vigencia_e_ativas
-        return solicitacoes.distinct().order_by('-data_log')
+        ).distinct().order_by('-data_log')
 
     @classmethod
     def get_negados_dieta_especial(cls, **kwargs):
@@ -656,14 +648,7 @@ class SolicitacoesEscola(MoldeConsolidado):
             dieta_alterada_id__isnull=False
         )
 
-        solicitacoes_de_cancelamento = cls.objects.filter(
-            escola_uuid=escola_uuid,
-            tipo_solicitacao_dieta='CANCELAMENTO_DIETA',
-            status_atual=PedidoAPartirDaEscolaWorkflow.ESCOLA_CANCELOU
-        )
-
         solicitacoes = solicitacoes_em_vigencia_e_ativas | solicitacoes_de_alteracao_para_escola_de_origem
-        solicitacoes = solicitacoes | solicitacoes_de_cancelamento
         return solicitacoes.distinct().order_by('-data_log')
 
     @classmethod


### PR DESCRIPTION
# Proposta

Este PR visa omitir a solicitação de cancelamento autorizada.

# Referência do Azure

- 59448

# Tarefas para concluir

- [x] omitir solicitação de cancelamento autorizada na filtragem