### PR TITLE
feature/34071-enviar-email-confirmacao-cancelamento

### DIFF
--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -530,8 +530,8 @@ class FluxoSolicitacaoRemessa(xwf_models.WorkflowEnabled, models.Model):
                 'solicitacao': self,
                 'log_transicao': log_transicao,
                 'url': url,
-                'REQUISICAO': self.numero_solicitacao,
-                'EMPRESA': self.distribuidor,
+                'requisicao': self.numero_solicitacao,
+                'empresa': self.distribuidor,
             }
         )
 
@@ -712,7 +712,8 @@ class FluxoSolicitacaoDeAlteracao(xwf_models.WorkflowEnabled, models.Model):
             vinculos__perfil__nome__in=(
                 'COORDENADOR_LOGISTICA',
                 'COORDENADOR_CODAE_DILOG_LOGISTICA',
-            )
+            ),
+            vinculos__ativo=True
         )
         return [usuario for usuario in queryset]
 

--- a/sme_terceirizadas/dados_comuns/templates/logistica_distribuidor_confirma_cancelamento.html
+++ b/sme_terceirizadas/dados_comuns/templates/logistica_distribuidor_confirma_cancelamento.html
@@ -2,7 +2,7 @@
 {% load email_templatetags %}
 
 {% block conteudo %}
-  <p>O cancelamento de guias de remessa da Requisição nº {{ REQUISICAO }} foi confirmado pela empresa {{ EMPRESA }},
+  <p>O cancelamento de guias de remessa da Requisição nº {{ requisicao }} foi confirmado pela empresa {{ empresa }},
     em {{ log_transicao.criado_em }}.</p>
   <br/>
   <a href="{{ url }}">Clique para acessar detalhes da solicitação</a>


### PR DESCRIPTION
Esta PR:

- Envia email de confirmação de cancelamento para usuários ativos da Dilog