### PR TITLE
Hotfix/60088-PeD-erro-ordenação-produtos-homologados

### DIFF
--- a/sme_terceirizadas/produto/api/viewsets.py
+++ b/sme_terceirizadas/produto/api/viewsets.py
@@ -321,7 +321,8 @@ class HomologacaoProdutoPainelGerencialViewSet(viewsets.ModelViewSet):
                 filtros['status__in'] = status__in
             else:
                 filtros['status'] = filtro_aplicado.upper()
-        query_set = self.get_queryset().filter(**filtros).distinct()
+        query_set = sorted(self.get_queryset().filter(**filtros).distinct(),
+                           key=lambda x: x.ultimo_log.criado_em, reverse=True)
         if page:
             page = self.paginate_queryset(query_set)
             serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
# Proposta

Esse PR visa ordenar queryset pela data do último log - método solicitacoes_homologacao_por_status

# Referência do Azure

- 60088

# Tarefas para concluir

- [x] ordenar queryset pela data do último log - método solicitacoes_homologacao_por_status