### PR TITLE
Dev - Atualizado até 04/04/22 as 17:45 (hotfix -- homolog > development)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -189,7 +189,7 @@ MIDDLEWARE = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
 STATIC_ROOT = str(ROOT_DIR('staticfiles'))
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
-STATIC_URL = '/code/staticfiles/'
+STATIC_URL = '/django_static/'
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = [
     str(APPS_DIR.path('static')),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -189,7 +189,7 @@ MIDDLEWARE = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-root
 STATIC_ROOT = str(ROOT_DIR('staticfiles'))
 # https://docs.djangoproject.com/en/dev/ref/settings/#static-url
-STATIC_URL = '/django_static/'
+STATIC_URL = '/code/staticfiles/'
 # https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = [
     str(APPS_DIR.path('static')),


### PR DESCRIPTION
Descendo hotfix - garantir ordenação de logs pelo campo 'criado_em' - de homolog para development