### PR TITLE
Feature/63650-DE-disparo-email-dietas-canceladas-manualmente-automaticamente

### DIFF
--- a/sme_terceirizadas/dieta_especial/api/viewsets.py
+++ b/sme_terceirizadas/dieta_especial/api/viewsets.py
@@ -311,18 +311,19 @@ class SolicitacaoDietaEspecialViewSet(
         justificativa = request.data.get('justificativa', '')
         solicitacao = self.get_object()
         try:
-            solicitacao.cancelar_pedido(
-                user=request.user, justificativa=justificativa)
-            solicitacao.ativo = False
-            solicitacao.save()
             if solicitacao.tipo_solicitacao == 'CANCELAMENTO_DIETA':
                 solicitacao.dieta_alterada.ativo = False
                 solicitacao.dieta_alterada.cancelar_pedido(
                     user=request.user, justificativa=solicitacao.logs.first().justificativa)
                 solicitacao.dieta_alterada.save()
-            if solicitacao.tipo_solicitacao == 'ALTERACAO_UE':
+            elif solicitacao.tipo_solicitacao == 'ALTERACAO_UE':
                 solicitacao.dieta_alterada.ativo = True
                 solicitacao.dieta_alterada.save()
+            else:
+                solicitacao.cancelar_pedido(
+                    user=request.user, justificativa=justificativa)
+                solicitacao.ativo = False
+                solicitacao.save()
             serializer = self.get_serializer(solicitacao)
             return Response(serializer.data)
         except InvalidTransitionError as e:

--- a/sme_terceirizadas/dieta_especial/templates/email/email_dieta_cancelada_automaticamente_terceirizada_escola_destino.html
+++ b/sme_terceirizadas/dieta_especial/templates/email/email_dieta_cancelada_automaticamente_terceirizada_escola_destino.html
@@ -1,0 +1,12 @@
+{% extends 'email_base.html' %}
+{% load email_templatetags %}
+
+{% block conteudo %}
+  <div style="font-size: 22px; color: #00a922;"><b>Cancelamento Automático da Dieta Especial</b></div>
+  <br/>
+  <div>O aluno {{ nome_aluno }} Código EOL {{ codigo_eol_aluno }} da Dieta Especial Número {{ dieta_numero }} da Unidade Educacional {{ nome_escola }} teve sua Dieta Cancelada {{ justificativa_cancelamento }}.</div>
+  <br/>
+  <div>Data do Cancelamento: {{ hoje }}.</div>
+  <br/>
+  <p>Para maiores detalhes acesse o sistema e consulte a solicitação.</p>
+{% endblock %}

--- a/sme_terceirizadas/dieta_especial/utils.py
+++ b/sme_terceirizadas/dieta_especial/utils.py
@@ -8,7 +8,7 @@ from sme_terceirizadas.perfil.models import Usuario
 from sme_terceirizadas.relatorios.relatorios import relatorio_dieta_especial_conteudo
 from sme_terceirizadas.relatorios.utils import html_to_pdf_email_anexo
 
-from ..dados_comuns.constants import TIPO_SOLICITACAO_DIETA
+from ..dados_comuns.constants import ADMINISTRADOR_TERCEIRIZADA, TIPO_SOLICITACAO_DIETA
 from ..dados_comuns.fluxo_status import DietaEspecialWorkflow
 from ..dados_comuns.utils import envia_email_unico, envia_email_unico_com_anexo_inmemory
 from ..escola.models import Aluno
@@ -206,6 +206,40 @@ def enviar_email_para_diretor_da_escola_destino(solicitacao_dieta, aluno, escola
     )
 
 
+def enviar_email_para_adm_terceirizada_da_escola_destino(solicitacao_dieta, aluno, escola, fora_da_rede=False):
+    assunto = f'Cancelamento Automático de Dieta Especial Nº {solicitacao_dieta.id_externo}'
+    hoje = date.today().strftime('%d/%m/%Y')
+    template = 'email/email_dieta_cancelada_automaticamente_terceirizada_escola_destino.html',
+    justificativa_cancelamento = 'por não pertencer a unidade educacional'
+    if fora_da_rede:
+        justificativa_cancelamento = 'por não estar matriculado'
+    dados_template = {
+        'nome_aluno': aluno.nome,
+        'codigo_eol_aluno': aluno.codigo_eol,
+        'dieta_numero': solicitacao_dieta.id_externo,
+        'nome_escola': escola.nome,
+        'hoje': hoje,
+        'justificativa_cancelamento': justificativa_cancelamento,
+    }
+    html = render_to_string(template, dados_template)
+    terceirizada = escola.lote.terceirizada
+    if terceirizada:
+        administradores_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(
+            ativo=True,
+            perfil__nome=ADMINISTRADOR_TERCEIRIZADA
+        )]
+
+        for email in administradores_terceirizadas:
+            envia_email_unico(
+                assunto=assunto,
+                corpo='',
+                email=email,
+                template=template,
+                dados_template=dados_template,
+                html=html,
+            )
+
+
 def aluno_matriculado_em_outra_ue(aluno, solicitacao_dieta):
     if(aluno.escola):
         return aluno.escola.codigo_eol != solicitacao_dieta.escola.codigo_eol
@@ -227,6 +261,14 @@ def cancela_dietas_ativas_automaticamente():  # noqa C901 D205 D400
             )
             gerar_log_dietas_ativas_canceladas_automaticamente(solicitacao_dieta, dados, fora_da_rede=True)
             _cancelar_dieta_aluno_fora_da_rede(dieta=solicitacao_dieta)
+            env = environ.Env()
+            if env('DJANGO_ENV') == 'production':
+                enviar_email_para_adm_terceirizada_da_escola_destino(
+                    solicitacao_dieta,
+                    aluno,
+                    escola=aluno.escola,
+                    fora_da_rede=True
+                )
         elif aluno_matriculado_em_outra_ue(aluno, solicitacao_dieta):
             dados = dict(
                 codigo_eol_aluno=aluno.codigo_eol,
@@ -240,8 +282,7 @@ def cancela_dietas_ativas_automaticamente():  # noqa C901 D205 D400
             _cancelar_dieta(solicitacao_dieta)
             env = environ.Env()
             if env('DJANGO_ENV') == 'production':
-                enviar_email_para_diretor_da_escola_origem(solicitacao_dieta, aluno, escola=solicitacao_dieta.escola)
-                enviar_email_para_diretor_da_escola_destino(solicitacao_dieta, aluno, escola=aluno.escola)
+                enviar_email_para_adm_terceirizada_da_escola_destino(solicitacao_dieta, aluno, escola=aluno.escola)
         else:
             continue
 


### PR DESCRIPTION
# Proposta

Este PR visa ajustar parte interessada para receber email de cancelamento aprovado pela nutricodae, por data de termino atingido, email de dietas canceladas por aluno não pertencer à rede e por mudar de ue - enviar para perfil ADMINISTRADOR_TERCEIRIZADA

# Referência do Azure

- 63650

# Tarefas para concluir

- [x] ajustar parte interessada para receber email de cancelamento aprovado pela nutricodae e por data de termino atingido
- [x] ajustar envio de email de dietas canceladas por aluno não pertencer à rede e por mudar de ue