### PR TITLE
comando para sujar base quando nao e producao

### DIFF
--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -2358,20 +2358,19 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
         user = kwargs['user']
         self.salvar_log_transicao(status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
                                   usuario=user)
-        if env('DJANGO_ENV') == 'production':
-            if self.tipo_solicitacao == 'ALTERACAO_UE':
-                assunto = 'Alerta de atendimento de Dieta Especial no CEI-Polo/Recreio nas férias'
-                titulo = 'Alerta de atendimento de Dieta Especial no CEI-Polo/Recreio nas férias'
-                dieta_origem = self.aluno.dietas_especiais.filter(
-                    tipo_solicitacao='COMUM',
-                    status=self.workflow_class.CODAE_AUTORIZADO).last()
-                self._envia_email_autorizar(assunto, titulo, user,
-                                            self._partes_interessadas_codae_autoriza, dieta_origem)
-            else:
-                assunto = '[SIGPAE] Status de solicitação - #' + self.id_externo
-                titulo = 'Status de Solicitação\n' + self.aluno.codigo_eol + ' ' + self.aluno.nome
-                self._preenche_template_e_envia_email(assunto, titulo, user,
-                                                      self._partes_interessadas_codae_autoriza_ou_nega, True)
+        if self.tipo_solicitacao == 'ALTERACAO_UE':
+            assunto = 'Alerta de atendimento de Dieta Especial no CEI-Polo/Recreio nas férias'
+            titulo = 'Alerta de atendimento de Dieta Especial no CEI-Polo/Recreio nas férias'
+            dieta_origem = self.aluno.dietas_especiais.filter(
+                tipo_solicitacao='COMUM',
+                status=self.workflow_class.CODAE_AUTORIZADO).last()
+            self._envia_email_autorizar(assunto, titulo, user,
+                                        self._partes_interessadas_codae_autoriza, dieta_origem)
+        else:
+            assunto = '[SIGPAE] Status de solicitação - #' + self.id_externo
+            titulo = 'Status de Solicitação\n' + self.aluno.codigo_eol + ' ' + self.aluno.nome
+            self._preenche_template_e_envia_email(assunto, titulo, user,
+                                                  self._partes_interessadas_codae_autoriza_ou_nega, True)
 
     @xworkflows.after_transition('inicia_fluxo_inativacao')
     def _inicia_fluxo_inativacao_hook(self, *args, **kwargs):

--- a/sme_terceirizadas/dieta_especial/utils.py
+++ b/sme_terceirizadas/dieta_especial/utils.py
@@ -1,6 +1,5 @@
 from datetime import date
 
-import environ
 from django.template.loader import render_to_string
 from rest_framework.pagination import PageNumberPagination
 
@@ -261,14 +260,12 @@ def cancela_dietas_ativas_automaticamente():  # noqa C901 D205 D400
             )
             gerar_log_dietas_ativas_canceladas_automaticamente(solicitacao_dieta, dados, fora_da_rede=True)
             _cancelar_dieta_aluno_fora_da_rede(dieta=solicitacao_dieta)
-            env = environ.Env()
-            if env('DJANGO_ENV') == 'production':
-                enviar_email_para_adm_terceirizada_da_escola_destino(
-                    solicitacao_dieta,
-                    aluno,
-                    escola=solicitacao_dieta.escola,
-                    fora_da_rede=True
-                )
+            enviar_email_para_adm_terceirizada_da_escola_destino(
+                solicitacao_dieta,
+                aluno,
+                escola=solicitacao_dieta.escola,
+                fora_da_rede=True
+            )
         elif aluno_matriculado_em_outra_ue(aluno, solicitacao_dieta):
             dados = dict(
                 codigo_eol_aluno=aluno.codigo_eol,
@@ -280,9 +277,7 @@ def cancela_dietas_ativas_automaticamente():  # noqa C901 D205 D400
             )
             gerar_log_dietas_ativas_canceladas_automaticamente(solicitacao_dieta, dados)
             _cancelar_dieta(solicitacao_dieta)
-            env = environ.Env()
-            if env('DJANGO_ENV') == 'production':
-                enviar_email_para_adm_terceirizada_da_escola_destino(solicitacao_dieta, aluno, escola=aluno.escola)
+            enviar_email_para_adm_terceirizada_da_escola_destino(solicitacao_dieta, aluno, escola=aluno.escola)
         else:
             continue
 

--- a/sme_terceirizadas/escola/management/commands/atualiza_dados_escolas.py
+++ b/sme_terceirizadas/escola/management/commands/atualiza_dados_escolas.py
@@ -127,6 +127,8 @@ class Command(BaseCommand):
 
         if escola_dados['email']:
             contato.email = escola_dados['email'].strip()
+            if env('DJANGO_ENV') != 'production':
+                contato.email = 'fake_' + contato.email
 
         if (
             escola_dados['telefone']

--- a/sme_terceirizadas/perfil/__tests__/commands/test_suja_base.py
+++ b/sme_terceirizadas/perfil/__tests__/commands/test_suja_base.py
@@ -1,0 +1,68 @@
+import os
+from unittest import TestCase, mock
+
+import pytest
+from django.core.management import call_command
+from model_mommy import mommy
+
+from sme_terceirizadas.dados_comuns.models import Contato
+from sme_terceirizadas.perfil.models import Usuario
+from sme_terceirizadas.terceirizada.models import Terceirizada
+
+
+class SujaBaseCommandTest(TestCase):
+    def call_command(self, *args, **kwargs):
+        call_command(
+            'suja_base',
+            *args,
+            **kwargs,
+        )
+
+    def setUp(self) -> None:
+        mommy.make(
+            Usuario,
+            nome='Fulano da Silva',
+            email='fulano@teste.com',
+            cpf='52347255100',
+            registro_funcional='1234567'
+        )
+        mommy.make(
+            Contato,
+            email='fulano_2@teste.com',
+        )
+        mommy.make(
+            Terceirizada,
+            representante_email='fulano_3@teste.com',
+            responsavel_email='fulano_4@teste.com',
+        )
+
+    @pytest.mark.django_db(transaction=True)
+    def test_command_suja_base(self) -> None:
+        usuario = Usuario.objects.get()
+        contato = Contato.objects.get()
+        terceirizada = Terceirizada.objects.get()
+        assert 'fake_' not in usuario.email
+        self.call_command()
+        usuario.refresh_from_db()
+        contato.refresh_from_db()
+        terceirizada.refresh_from_db()
+        assert 'fake_' in usuario.email
+        assert 'fake_' in contato.email
+        assert 'fake_' in terceirizada.representante_email
+        assert 'fake_' in terceirizada.responsavel_email
+
+    @mock.patch.dict(os.environ, {'DJANGO_ENV': 'production'})
+    @pytest.mark.django_db(transaction=True)
+    def test_command_suja_base_django_env_production(self) -> None:
+        usuario = Usuario.objects.get()
+        contato = Contato.objects.get()
+        terceirizada = Terceirizada.objects.get()
+        assert 'fake_' not in usuario.email
+        self.call_command()
+        usuario.refresh_from_db()
+        contato.refresh_from_db()
+        terceirizada.refresh_from_db()
+        assert 'fake_' not in usuario.email
+        assert 'fake_' not in contato.email
+        assert 'fake_' not in terceirizada.representante_email
+        assert 'fake_' not in terceirizada.responsavel_email

--- a/sme_terceirizadas/perfil/management/commands/suja_base.py
+++ b/sme_terceirizadas/perfil/management/commands/suja_base.py
@@ -1,0 +1,74 @@
+import logging
+
+import environ
+from django.core.management import BaseCommand
+from django.db.models import Q, Value
+from django.db.models.functions import Concat
+
+from sme_terceirizadas.dados_comuns.models import Contato
+from sme_terceirizadas.perfil.models import Usuario
+from sme_terceirizadas.terceirizada.models import Terceirizada
+
+logger = logging.getLogger('sigpae.cmd_suja_base')
+
+env = environ.Env()
+
+
+class Command(BaseCommand):
+    help = 'Suja base de dados para que não tenha e-mails verdadeiros em ambientes que não são produção'
+
+    def handle(self, *args, **options):
+        if env('DJANGO_ENV') == 'production':
+            self.stdout.write(self.style.ERROR(f'PRODUÇÃO! NÃO PODE SUJAR A BASE'))
+            return
+        filtro_ignorar = (
+            Q(email__isnull=True) |
+            Q(email='') |
+            Q(email__icontains='fake_') |
+            Q(email__icontains='@admin.com') |
+            Q(email__icontains='@amcom.com')
+        )
+        self.suja_emails_usuarios(filtro_ignorar)
+        self.suja_emails_contatos(filtro_ignorar)
+        self.suja_representante_emails_terceirizadas()
+        self.suja_responsavel_emails_terceirizadas()
+
+    def suja_emails_usuarios(self, filtro):
+        usuarios = Usuario.objects.exclude(filtro)
+        self.stdout.write(self.style.SUCCESS(f'Atualizando {usuarios.count()} usuarios'))
+        qtd_atualizados = usuarios.update(email=Concat(Value('fake_'), 'email'))
+        self.stdout.write(self.style.SUCCESS(f'{qtd_atualizados} atualizados'))
+
+    def suja_emails_contatos(self, filtro):
+        contatos = Contato.objects.exclude(filtro)
+        self.stdout.write(self.style.SUCCESS(f'Atualizando {contatos.count()} contatos'))
+        qtd_contatos = contatos.update(email=Concat(Value('fake_'), 'email'))
+        self.stdout.write(self.style.SUCCESS(f'{qtd_contatos} atualizados'))
+
+    def suja_representante_emails_terceirizadas(self):
+        terceirizadas_representante_email = Terceirizada.objects.exclude(
+            Q(representante_email__isnull=True) |
+            Q(representante_email='') |
+            Q(representante_email__icontains='fake_') |
+            Q(representante_email__icontains='@admin.com') |
+            Q(representante_email__icontains='@amcom.com')
+        )
+        self.stdout.write(self.style.SUCCESS(f'Atualizando {terceirizadas_representante_email.count()} '
+                                             f'terceirizadas no campo representante_email'))
+        qtd_terceirizadas = terceirizadas_representante_email.update(
+            representante_email=Concat(Value('fake_'), 'representante_email'))
+        self.stdout.write(self.style.SUCCESS(f'{qtd_terceirizadas} atualizados'))
+
+    def suja_responsavel_emails_terceirizadas(self):
+        terceirizadas_responsavel_email = Terceirizada.objects.exclude(
+            Q(responsavel_email__isnull=True) |
+            Q(responsavel_email='') |
+            Q(responsavel_email__icontains='fake_') |
+            Q(responsavel_email__icontains='@admin.com') |
+            Q(responsavel_email__icontains='@amcom.com')
+        )
+        self.stdout.write(self.style.SUCCESS(f'Atualizando {terceirizadas_responsavel_email.count()} '
+                                             f'terceirizadas no campo responsavel_email'))
+        qtd_terceirizadas = terceirizadas_responsavel_email.update(
+            responsavel_email=Concat(Value('fake_'), 'responsavel_email'))
+        self.stdout.write(self.style.SUCCESS(f'{qtd_terceirizadas} atualizados'))


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o envio de e-mails em ambiente de teste para e-mails reais

# Referência do Azure

- 64367

# Tarefas para concluir

- [x] criar comando para sujar base, para não haver e-mails reais quando não é produção.
- [x] remove trava de envio de e-mail pela aplicação (agora não mais necessária) 