### PR TITLE
hotfix/mensagem-autenticacao-papa-x-sigpae

### DIFF
--- a/sme_terceirizadas/logistica/api/soup/token_auth.py
+++ b/sme_terceirizadas/logistica/api/soup/token_auth.py
@@ -18,7 +18,7 @@ class TokenAuthentication():
             raise exceptions.AuthenticationFailed('Token inválido. Não foi enviado informações de credenciais.')
 
         if not hasattr(oWsAcessoModel, 'StrToken'):
-            raise exceptions.AuthenticationFailed('Token inválido.')
+            raise exceptions.AuthenticationFailed('Falha na autenticação. StrToken não foi informado.')
 
         token = oWsAcessoModel.StrToken
 


### PR DESCRIPTION
Este Hotfix:

- Altera mensagem de erro de autenticação para que o processo fique mais claro.