### PR TITLE
corrige regra de negocio importacao de dietas + testes

### DIFF
--- a/sme_terceirizadas/dieta_especial/admin.py
+++ b/sme_terceirizadas/dieta_especial/admin.py
@@ -104,6 +104,7 @@ class SolicitacaoDietaEspecialAdmin(admin.ModelAdmin):
     search_fields = ('uuid', 'aluno__codigo_eol', 'aluno__nome')
     readonly_fields = ('aluno',)
     list_filter = ('eh_importado', 'conferido')
+    filter_horizontal = ('alergias_intolerancias',)
     change_list_template = 'dieta_especial/change_list.html'
     inlines = (SubstituicaoAlimentoInline,)
 

--- a/sme_terceirizadas/processamento_arquivos/dieta_especial/__tests__/conftest.py
+++ b/sme_terceirizadas/processamento_arquivos/dieta_especial/__tests__/conftest.py
@@ -2,9 +2,12 @@ import pytest
 from model_mommy import mommy
 
 from sme_terceirizadas.dieta_especial.models import (
+    AlergiaIntolerancia,
     ArquivoCargaAlimentosSubstitutos,
     ArquivoCargaDietaEspecial,
-    ArquivoCargaUsuariosEscola
+    ArquivoCargaUsuariosEscola,
+    ClassificacaoDieta,
+    SolicitacaoDietaEspecial
 )
 
 
@@ -21,3 +24,27 @@ def arquivo_carga_alimentos_e_substitutos():
 @pytest.fixture
 def arquivo_carga_usuarios_escola():
     return mommy.make(ArquivoCargaUsuariosEscola)
+
+
+@pytest.fixture
+def dieta_especial_ativa():
+    aluno = mommy.make('escola.Aluno', codigo_eol='1234567', nome='TESTE ALUNO DIETA')
+    escola = mommy.make('escola.Escola', codigo_codae='12345678')
+    classificacao = mommy.make(ClassificacaoDieta, nome='Tipo A')
+    alergias_set = mommy.prepare(AlergiaIntolerancia, descricao='Aluno Alérgico', _quantity=1)
+    solicitacao = mommy.make(
+        SolicitacaoDietaEspecial,
+        aluno=aluno,
+        ativo=True,
+        classificacao=classificacao,
+        escola_destino=escola,
+        nome_protocolo='Alérgico',
+        alergias_intolerancias=alergias_set,
+        eh_importado=True
+    )
+    return solicitacao
+
+
+@pytest.fixture
+def usuario():
+    return mommy.make('perfil.Usuario')

--- a/sme_terceirizadas/processamento_arquivos/dieta_especial/__tests__/test_importacao_dietas_especiais.py
+++ b/sme_terceirizadas/processamento_arquivos/dieta_especial/__tests__/test_importacao_dietas_especiais.py
@@ -1,0 +1,50 @@
+import pytest
+
+from sme_terceirizadas.dieta_especial.models import ClassificacaoDieta
+from sme_terceirizadas.escola.models import Escola
+
+from ..importa_dietas_especiais import ProcessadorPlanilha
+from ..schemas import ArquivoCargaDietaEspecialSchema
+
+pytestmark = pytest.mark.django_db
+
+
+def test_eh_exatamente_mesma_solicitacao(dieta_especial_ativa, arquivo_carga_dieta_especial, usuario):
+    dicionario_dados = {
+        'dre': 'BT',
+        'tipo_gestao': 'Terceirizada',
+        'tipo_unidade': 'DIRETA',
+        'codigo_escola': '12345678',
+        'nome_unidade': 'Uma Unidade',
+        'codigo_eol_aluno': '1234567',
+        'nome_aluno': 'Anderson Marques',
+        'data_nascimento': '11/01/1989',
+        'data_ocorrencia': '11/01/1989',
+        'codigo_diagnostico': 'Aluno Alérgico',
+        'protocolo_dieta': 'Alérgico',
+        'codigo_categoria_dieta': 'A'
+    }
+    solicitacao_dieta_schema = ArquivoCargaDietaEspecialSchema(**dicionario_dados)
+    processador = ProcessadorPlanilha(usuario, arquivo_carga_dieta_especial)
+    with pytest.raises(Exception):
+        processador.eh_exatamente_mesma_solicitacao(solicitacao=dieta_especial_ativa,
+                                                    solicitacao_dieta_schema=solicitacao_dieta_schema)
+    with pytest.raises(Exception):
+        processador.consulta_relacao_lote_terceirizada(solicitacao=dieta_especial_ativa)
+    monta_diagnosticos = processador.monta_diagnosticos('Aluno Alérgico;Aluno Diabético')
+    assert len(monta_diagnosticos) == 2
+    assert [diagnotisco.descricao for diagnotisco in monta_diagnosticos] == ['ALUNO ALÉRGICO', 'ALUNO DIABÉTICO']
+    assert processador.consulta_classificacao(solicitacao_dieta_schema) == ClassificacaoDieta.objects.get(nome='Tipo A')
+    dicionario_dados_categoria_incorreta = dicionario_dados
+    dicionario_dados_categoria_incorreta['codigo_categoria_dieta'] = 'B'
+    solicitacao_dieta_schema_categoria_incorreta = ArquivoCargaDietaEspecialSchema(
+        **dicionario_dados_categoria_incorreta)
+    with pytest.raises(Exception):
+        processador.consulta_classificacao(solicitacao_dieta_schema_categoria_incorreta)
+    assert processador.consulta_escola(solicitacao_dieta_schema) == Escola.objects.get(codigo_codae='12345678')
+    dicionario_dados_escola_incorreta = dicionario_dados
+    dicionario_dados_escola_incorreta['codigo_escola'] = '12345679'
+    solicitacao_dieta_schema_escola_incorreta = ArquivoCargaDietaEspecialSchema(
+        **dicionario_dados_escola_incorreta)
+    with pytest.raises(Exception):
+        processador.consulta_escola(solicitacao_dieta_schema_escola_incorreta)


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a regra de negócio de importação de dieta especiais:
caso já exista uma dieta especial ATIVA para um determinado aluno (independente se é importada ou não), esta dieta deve ser INATIVADA, e a nova dieta importada deve ser a ATIVA.

- 66786

# Tarefas para concluir

- [x] corrigir regra de negocio
- [x] testes unitários para maior robustez 