### PR TITLE
Feature/67460-DE-incluir-disparo-de-emails-dietas-canceladas-para-contato-email-escola

### DIFF
--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -2204,19 +2204,22 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
 
         A dieta especial termina quando a data de término é atingida.
         São as partes interessadas:
-            - perfil "ADMINISTRADOR_TERCEIRIZADA" vinculado à terceirizada relacionda
+            - perfil "ADMINISTRADOR_TERCEIRIZADA" vinculado à terceirizada relacionada
               à escola destino da dieta
+            - email de contato da escola (escola.contato.email)
         """
         escola = self.escola_destino
         try:
             terceirizada = escola.lote.terceirizada
-            administradores_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(
+            email_administradores_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(
                 ativo=True,
                 perfil__nome=ADMINISTRADOR_TERCEIRIZADA
             )]
+            email_escola_eol = [escola.contato.email]
+            email_lista = email_administradores_terceirizadas + email_escola_eol
         except AttributeError:
-            administradores_terceirizadas = []
-        return administradores_terceirizadas
+            email_lista = []
+        return email_lista
 
     @property  # noqa c901
     def _partes_interessadas_codae_autoriza_ou_nega(self):
@@ -2262,13 +2265,15 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
         escola = self.escola_destino
         try:
             terceirizada = escola.lote.terceirizada
-            administradores_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(
+            email_administradores_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(
                 ativo=True,
                 perfil__nome=ADMINISTRADOR_TERCEIRIZADA
             )]
+            email_escola_eol = [escola.contato.email]
+            email_lista = email_administradores_terceirizadas + email_escola_eol
         except AttributeError:
-            administradores_terceirizadas = []
-        return administradores_terceirizadas
+            email_lista = []
+        return email_lista
 
     @property
     def template_mensagem(self):

--- a/sme_terceirizadas/dieta_especial/utils.py
+++ b/sme_terceirizadas/dieta_especial/utils.py
@@ -205,7 +205,7 @@ def enviar_email_para_diretor_da_escola_destino(solicitacao_dieta, aluno, escola
     )
 
 
-def enviar_email_para_adm_terceirizada_da_escola_destino(solicitacao_dieta, aluno, escola, fora_da_rede=False):
+def enviar_email_para_adm_terceirizada_e_escola(solicitacao_dieta, aluno, escola, fora_da_rede=False):
     assunto = f'Cancelamento Automático de Dieta Especial Nº {solicitacao_dieta.id_externo}'
     hoje = date.today().strftime('%d/%m/%Y')
     template = 'email/email_dieta_cancelada_automaticamente_terceirizada_escola_destino.html',
@@ -223,20 +223,21 @@ def enviar_email_para_adm_terceirizada_da_escola_destino(solicitacao_dieta, alun
     html = render_to_string(template, dados_template)
     terceirizada = escola.lote.terceirizada
     if terceirizada:
-        administradores_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(
+        email_administradores_terceirizadas = [vinculo.usuario.email for vinculo in terceirizada.vinculos.filter(
             ativo=True,
             perfil__nome=ADMINISTRADOR_TERCEIRIZADA
         )]
-
-        for email in administradores_terceirizadas:
-            envia_email_unico(
-                assunto=assunto,
-                corpo='',
-                email=email,
-                template=template,
-                dados_template=dados_template,
-                html=html,
-            )
+    email_escola = [escola.contato.email]
+    email_lista = email_administradores_terceirizadas + email_escola
+    for email in email_lista:
+        envia_email_unico(
+            assunto=assunto,
+            corpo='',
+            email=email,
+            template=template,
+            dados_template=dados_template,
+            html=html,
+        )
 
 
 def aluno_matriculado_em_outra_ue(aluno, solicitacao_dieta):
@@ -260,7 +261,7 @@ def cancela_dietas_ativas_automaticamente():  # noqa C901 D205 D400
             )
             gerar_log_dietas_ativas_canceladas_automaticamente(solicitacao_dieta, dados, fora_da_rede=True)
             _cancelar_dieta_aluno_fora_da_rede(dieta=solicitacao_dieta)
-            enviar_email_para_adm_terceirizada_da_escola_destino(
+            enviar_email_para_adm_terceirizada_e_escola(
                 solicitacao_dieta,
                 aluno,
                 escola=solicitacao_dieta.escola,
@@ -277,7 +278,7 @@ def cancela_dietas_ativas_automaticamente():  # noqa C901 D205 D400
             )
             gerar_log_dietas_ativas_canceladas_automaticamente(solicitacao_dieta, dados)
             _cancelar_dieta(solicitacao_dieta)
-            enviar_email_para_adm_terceirizada_da_escola_destino(solicitacao_dieta, aluno, escola=aluno.escola)
+            enviar_email_para_adm_terceirizada_e_escola(solicitacao_dieta, aluno, escola=solicitacao_dieta.escola)
         else:
             continue
 


### PR DESCRIPTION
# Proposta

Este PR visa incluir email do contato de escola para receber email quando nutricodae cancela dieta manualmente, quando dieta atinge data de término, quando dieta é cancelada automaticamente por aluno não estar matriculado e por estar matriculado em outra ue

# Referência do Azure

- 67460

# Tarefas para concluir

- [x] incluir email do contato de escola para receber email quando nutricodae cancela dieta manualmente e quando dieta atinge data de término
- [x] incluir email do contato de escola para receber email quando dieta é cancelada automaticamente por aluno não estar matriculado e por estar matriculado em outra ue