### PR TITLE
Feature/67460-DE-incluir-disparo-de-emails-dietas-canceladas-para-contato-email-escola

### DIFF
--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -2352,9 +2352,10 @@ class FluxoDietaEspecialPartindoDaEscola(xwf_models.WorkflowEnabled, models.Mode
         self.salvar_log_transicao(status_evento=LogSolicitacoesUsuario.ESCOLA_CANCELOU,
                                   usuario=user,
                                   justificativa=justificativa)
-        self._preenche_template_e_envia_email(assunto, titulo, user,
-                                              self._partes_interessadas_codae_cancela,
-                                              'cancelar_pedido' if alta_medica else None)
+        if self.tipo_solicitacao != 'CANCELAMENTO_DIETA':
+            self._preenche_template_e_envia_email(assunto, titulo, user,
+                                                  self._partes_interessadas_codae_cancela,
+                                                  'cancelar_pedido' if alta_medica else None)
 
     @xworkflows.after_transition('negar_cancelamento_pedido')
     def _negar_cancelamento_pedido_hook(self, *args, **kwargs):


### PR DESCRIPTION
# Proposta

Este PR visa evitar envio de email duplicado - usuário já recebe email de cancelamento da solicitação do tipo 'COMUM'

# Referência do Azure

- 67460

# Tarefas para concluir

- [x] evitar envio de email duplicado - usuário já recebe email de cancelamento da solicitação do tipo 'COMUM'