### PR TITLE
Feature/68881-PeD-validação-de-log-análise-sensorial

### DIFF
--- a/sme_terceirizadas/produto/api/serializers/serializers.py
+++ b/sme_terceirizadas/produto/api/serializers/serializers.py
@@ -255,6 +255,8 @@ class ProdutoSerializer(serializers.ModelSerializer):
 
     especificacoes = serializers.SerializerMethodField()
 
+    vinculos_produto_edital = serializers.SerializerMethodField()
+
     def get_homologacoes(self, obj):
         return HomologacaoProdutoComUltimoLogSerializer(
             HomologacaoProduto.objects.filter(
@@ -273,6 +275,13 @@ class ProdutoSerializer(serializers.ModelSerializer):
     def get_especificacoes(self, obj):
         return EspecificacaoProdutoSerializer(
             EspecificacaoProduto.objects.filter(
+                produto=obj
+            ), many=True
+        ).data
+
+    def get_vinculos_produto_edital(self, obj):
+        return ProdutoEditalSerializer(
+            ProdutoEdital.objects.filter(
                 produto=obj
             ), many=True
         ).data

--- a/sme_terceirizadas/produto/api/viewsets.py
+++ b/sme_terceirizadas/produto/api/viewsets.py
@@ -1087,7 +1087,13 @@ class ProdutoViewSet(viewsets.ModelViewSet):
         form_data = form.cleaned_data.copy()
         form_data['status'] = [
             HomologacaoProdutoWorkflow.CODAE_HOMOLOGADO,
-            HomologacaoProdutoWorkflow.ESCOLA_OU_NUTRICIONISTA_RECLAMOU
+            HomologacaoProdutoWorkflow.ESCOLA_OU_NUTRICIONISTA_RECLAMOU,
+            HomologacaoProdutoWorkflow.CODAE_PEDIU_ANALISE_SENSORIAL,
+            HomologacaoProdutoWorkflow.CODAE_PEDIU_ANALISE_RECLAMACAO,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_UE,
+            HomologacaoProdutoWorkflow.UE_RESPONDEU_QUESTIONAMENTO,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_NUTRISUPERVISOR,
+            HomologacaoProdutoWorkflow.NUTRISUPERVISOR_RESPONDEU_QUESTIONAMENTO
         ]
 
         queryset = self.get_queryset_filtrado(form_data)
@@ -1101,7 +1107,13 @@ class ProdutoViewSet(viewsets.ModelViewSet):
         form_data = form.cleaned_data.copy()
         form_data['status'] = [
             HomologacaoProdutoWorkflow.CODAE_HOMOLOGADO,
-            HomologacaoProdutoWorkflow.ESCOLA_OU_NUTRICIONISTA_RECLAMOU
+            HomologacaoProdutoWorkflow.ESCOLA_OU_NUTRICIONISTA_RECLAMOU,
+            HomologacaoProdutoWorkflow.CODAE_PEDIU_ANALISE_SENSORIAL,
+            HomologacaoProdutoWorkflow.CODAE_PEDIU_ANALISE_RECLAMACAO,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_UE,
+            HomologacaoProdutoWorkflow.UE_RESPONDEU_QUESTIONAMENTO,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_NUTRISUPERVISOR,
+            HomologacaoProdutoWorkflow.NUTRISUPERVISOR_RESPONDEU_QUESTIONAMENTO
         ]
 
         queryset = self.get_queryset_filtrado(form_data)
@@ -1138,7 +1150,13 @@ class ProdutoViewSet(viewsets.ModelViewSet):
         form_data = form.cleaned_data.copy()
         form_data['status'] = [
             HomologacaoProdutoWorkflow.CODAE_HOMOLOGADO,
-            HomologacaoProdutoWorkflow.ESCOLA_OU_NUTRICIONISTA_RECLAMOU
+            HomologacaoProdutoWorkflow.ESCOLA_OU_NUTRICIONISTA_RECLAMOU,
+            HomologacaoProdutoWorkflow.CODAE_PEDIU_ANALISE_SENSORIAL,
+            HomologacaoProdutoWorkflow.CODAE_PEDIU_ANALISE_RECLAMACAO,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_UE,
+            HomologacaoProdutoWorkflow.UE_RESPONDEU_QUESTIONAMENTO,
+            HomologacaoProdutoWorkflow.CODAE_QUESTIONOU_NUTRISUPERVISOR,
+            HomologacaoProdutoWorkflow.NUTRISUPERVISOR_RESPONDEU_QUESTIONAMENTO
         ]
 
         queryset = self.get_queryset_filtrado(form_data)

--- a/sme_terceirizadas/produto/api/viewsets.py
+++ b/sme_terceirizadas/produto/api/viewsets.py
@@ -1765,24 +1765,9 @@ class RespostaAnaliseSensorialViewSet(viewsets.ModelViewSet):
                     user=request.user, justificativa=justificativa
                 )
             else:
-                # Respondendo análise sensorial vindo de uma Homologação de produto homologada.
-                logs_homologados = homologacao.logs.filter(status_evento=LogSolicitacoesUsuario.CODAE_HOMOLOGADO).all()
-
-                # Essa validação não está funcionando
-                # caso de erro:
-                # Tercerizada Solicitou > CODAE Homologou > CODAE Suspendeu
-                # Terceirzada Corrigiu > CODAE Solicita análise sensorial
-                # Produto vai direto para homologado
-                # o último log de CODAE_HOMOLOGADO deve ser novo que o último log de CODAE_PENDENTE_HOMOLOGACAO
-                if logs_homologados:
-                    homologacao.terceirizada_responde_analise_sensorial_homologado(
-                        user=request.user, justificativa=justificativa
-                    )
-                else:
-                    # Respondendo análise sensorial vindo de uma Homologação de produto pendente.
-                    homologacao.terceirizada_responde_analise_sensorial(
-                        user=request.user, justificativa=justificativa
-                    )
+                homologacao.terceirizada_responde_analise_sensorial(
+                    user=request.user, justificativa=justificativa
+                )
             serializer.save()
 
             analise_sensorial = homologacao.ultima_analise

--- a/sme_terceirizadas/produto/api/viewsets.py
+++ b/sme_terceirizadas/produto/api/viewsets.py
@@ -466,12 +466,17 @@ class HomologacaoProdutoViewSet(viewsets.ModelViewSet):
                 user=request.user,
                 link_pdf=url_configs('API', {'uri': uri}))
             eh_para_alunos_com_dieta = homologacao_produto.produto.eh_para_alunos_com_dieta
+            vinculos_produto_edital = homologacao_produto.produto.vinculos.all()
+            array_uuids_vinc = [str(value)
+                                for value
+                                in [*vinculos_produto_edital.values_list('edital__uuid', flat=True)]]
             for edital_uuid in editais:
-                ProdutoEdital.objects.create(
-                    produto=homologacao_produto.produto,
-                    edital=Edital.objects.get(uuid=edital_uuid),
-                    tipo_produto=ProdutoEdital.DIETA_ESPECIAL if eh_para_alunos_com_dieta else ProdutoEdital.COMUM
-                )
+                if edital_uuid not in array_uuids_vinc:
+                    ProdutoEdital.objects.create(
+                        produto=homologacao_produto.produto,
+                        edital=Edital.objects.get(uuid=edital_uuid),
+                        tipo_produto=ProdutoEdital.DIETA_ESPECIAL if eh_para_alunos_com_dieta else ProdutoEdital.COMUM
+                    )
             serializer = self.get_serializer(homologacao_produto)
             return Response(serializer.data)
         except InvalidTransitionError as e:


### PR DESCRIPTION
# Proposta

Este PR visa criar inserir campo vinculos_produto_edital no serializer ProdutoSerializer, ajustar criação de vínculos ProdutoEdital, ajustar status para endpoints de relatório de produtos homologados e impressão

# Referência do Azure

- 68881

# Tarefas para concluir

- [x] inserir campo vinculos_produto_edital no serializer ProdutoSerializer
- [x] criar somente vínculos de Produto Edital não existentes para tal homologação
- [x] remover código que criava log de homologado após resposta de análise sensorial
- [x] ajustar status para endpoints de relatório de produtos homologados e impressão