### PR TITLE
Feature/76462-PeD-tela-vincular-produtos-editais-incluir-campo-tipo-produto-edital-origem

### DIFF
--- a/sme_terceirizadas/produto/api/viewsets.py
+++ b/sme_terceirizadas/produto/api/viewsets.py
@@ -1757,9 +1757,14 @@ class ProdutosEditaisViewSet(viewsets.ModelViewSet):
     def lista_produtos_opcoes(self, request):
         try:
             editais_uuid = request.query_params.get('editais', '')
+            tipo_produto_edital_origem = request.query_params.get('tipo_produto_edital_origem', '')
             editais_uuid = editais_uuid.split(';')
-            queryset = self.get_queryset().filter(edital__uuid__in=editais_uuid).order_by('produto__nome',
-                                                                                          'produto__marca__nome')
+            queryset = self.get_queryset().filter(edital__uuid__in=editais_uuid)
+            if tipo_produto_edital_origem.lower() == ProdutoEdital.TIPO_PRODUTO['COMUM'].lower():
+                queryset = queryset.filter(tipo_produto__icontains=ProdutoEdital.TIPO_PRODUTO['COMUM'])
+            else:
+                queryset = queryset.exclude(tipo_produto__icontains=ProdutoEdital.TIPO_PRODUTO['COMUM'])
+            queryset = queryset.order_by('produto__nome', 'produto__marca__nome')
             data = self.get_serializer(queryset, many=True).data
             return Response(data=data, status=status.HTTP_200_OK)
         except Exception as e:


### PR DESCRIPTION
# Proposta

Este PR visa incluir filtro de tipo de produto para edital de origem no endpoint lista-produtos-opcoes

# Referência do Azure

- 76462

# Tarefas para concluir

- [x] incluir filtro de tipo de produto para edital de origem no endpoint lista-produtos-opcoes