### PR TITLE
Feature/76330 cadastrar protocolo padrao em editais distintos

### DIFF
--- a/sme_terceirizadas/dieta_especial/__tests__/test_managers.py
+++ b/sme_terceirizadas/dieta_especial/__tests__/test_managers.py
@@ -1,0 +1,15 @@
+import pytest
+from model_mommy import mommy
+
+from sme_terceirizadas.terceirizada.models import Edital
+
+pytestmark = pytest.mark.django_db
+
+
+def test_manager_edital_check_name_alrady_in_edital_ok():
+    edital_1 = mommy.make('terceirizada.Edital', numero='Edital Numero 1')
+    edital_2 = mommy.make('terceirizada.Edital', numero='Edital Numero 2')
+    editais = [edital_1.uuid, edital_2.uuid]
+    mommy.make('dieta_especial.ProtocoloPadraoDietaEspecial', nome_protocolo='ALERGIA - ABACATE', editais=[edital_1])
+    assert 'Edital Numero 1' in Edital.objects.check_editais_already_has_nome_protocolo(
+        editais, 'ALERGIA - ABACATE')[0]['numero']

--- a/sme_terceirizadas/dieta_especial/__tests__/test_urls.py
+++ b/sme_terceirizadas/dieta_especial/__tests__/test_urls.py
@@ -803,7 +803,7 @@ def test_cadastro_protocolo_dieta_especial(client_autenticado_protocolo_dieta):
                                                        content_type='application/json',
                                                        data=data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()[0] == 'Já existe um protocolo padrão com esse nome.'
+    assert 'Já existe um protocolo padrão com esse nome' in response.json()[0]
     data['nome_protocolo'] = 'ALERGIA - BANANA'
     client_autenticado_protocolo_dieta.post('/protocolo-padrao-dieta-especial/',
                                             content_type='application/json',
@@ -812,7 +812,7 @@ def test_cadastro_protocolo_dieta_especial(client_autenticado_protocolo_dieta):
                                                           content_type='application/json',
                                                           data=data)
     assert response_400.status_code == status.HTTP_400_BAD_REQUEST
-    assert response_400.json()[0] == 'Já existe um protocolo padrão com esse nome.'
+    assert 'Já existe um protocolo padrão com esse nome' in response_400.json()[0]
     data['nome_protocolo'] = 'ALERGIA - ABACATE'
     data['editais'] = []
     response = client_autenticado_protocolo_dieta.put(f'/protocolo-padrao-dieta-especial/{uuid}/',

--- a/sme_terceirizadas/dieta_especial/__tests__/test_validators.py
+++ b/sme_terceirizadas/dieta_especial/__tests__/test_validators.py
@@ -1,6 +1,8 @@
 import pytest
 from rest_framework.exceptions import ValidationError
 
+from sme_terceirizadas.dieta_especial.api.validators import edital_ja_existe_protocolo
+
 from ...dados_comuns.validators import deve_ter_extensao_valida
 
 pytestmark = pytest.mark.django_db
@@ -14,3 +16,12 @@ def test_extensoes_validas(nomes_arquivos_validos):
 def test_extensoes_invalidas(nomes_arquivos_invalidos):
     with pytest.raises(ValidationError, match='Extensão inválida'):
         deve_ter_extensao_valida(nomes_arquivos_invalidos)
+
+
+@pytest.mark.parametrize('editais,msg_esperada', [
+    ([{'numero': 'E1'}], 'Já existe um protocolo padrão com esse nome.'),
+    ([{'numero': 'E1'}, {'numero': 'E2'}], 'Já existe um protocolo padrão com esse nome para os editais: E1, E2.')
+])
+def test_edital_ja_existe_protocolo(editais, msg_esperada):
+    with pytest.raises(ValidationError, match=msg_esperada):
+        edital_ja_existe_protocolo(editais)

--- a/sme_terceirizadas/dieta_especial/api/serializers_create.py
+++ b/sme_terceirizadas/dieta_especial/api/serializers_create.py
@@ -23,7 +23,7 @@ from ..models import (
     SubstituicaoAlimentoProtocoloPadrao
 )
 from ..utils import log_create, log_update
-from .validators import AlunoSerializerValidator
+from .validators import AlunoSerializerValidator, edital_ja_existe_protocolo
 
 
 class AnexoCreateSerializer(serializers.ModelSerializer):
@@ -315,9 +315,9 @@ class ProtocoloPadraoDietaEspecialSerializerCreate(serializers.ModelSerializer):
         substituicoes = validated_data.pop('substituicoes')
         nome_protocolo = validated_data['nome_protocolo']
         editais = validated_data.pop('editais')
-        protocolos = ProtocoloPadraoDietaEspecial.objects.all()
-        if (nome_protocolo.upper() in [protocolo.nome_protocolo.upper() for protocolo in protocolos]):
-            raise serializers.ValidationError('Já existe um protocolo padrão com esse nome.')
+        protocolos = Edital.objects.check_editais_already_has_nome_protocolo(editais, nome_protocolo)
+        if (protocolos):
+            edital_ja_existe_protocolo(protocolos)
         validated_data['nome_protocolo'] = nome_protocolo.upper()
         protocolo_padrao = ProtocoloPadraoDietaEspecial.objects.create(**validated_data)
         if editais and len(editais):
@@ -344,16 +344,19 @@ class ProtocoloPadraoDietaEspecialSerializerCreate(serializers.ModelSerializer):
 
     def update(self, instance, validated_data): # noqa C901
         editais = validated_data.pop('editais')
+        nome_protocolo = validated_data['nome_protocolo']
+        protocolos = Edital.objects.check_editais_already_has_nome_protocolo(
+            editais, nome_protocolo)
+        if(nome_protocolo == self.instance.nome_protocolo):
+            protocolos = protocolos.exclude(uuid__in=list(instance.editais.values_list('uuid', flat=True)))
+        if (protocolos):
+            edital_ja_existe_protocolo(protocolos)
         instance.editais.clear()
         if editais and len(editais):
             instance.editais.set(Edital.objects.filter(uuid__in=editais))
 
         substituicoes = validated_data.pop('substituicoes')
 
-        nome_protocolo = validated_data['nome_protocolo']
-        protocolos = ProtocoloPadraoDietaEspecial.objects.all().exclude(uuid=instance.uuid)
-        if (nome_protocolo.upper() in [protocolo.nome_protocolo.upper() for protocolo in protocolos]):
-            raise serializers.ValidationError('Já existe um protocolo padrão com esse nome.')
         validated_data['nome_protocolo'] = nome_protocolo.upper()
         user = None
         request = self.context.get('request')

--- a/sme_terceirizadas/dieta_especial/api/validators.py
+++ b/sme_terceirizadas/dieta_especial/api/validators.py
@@ -34,7 +34,7 @@ def somente_digitos(codigo_eol):
         raise serializers.ValidationError('Deve ter somente dígitos')
 
 
-def edital_ja_existe_protocolo(editais: str):
+def edital_ja_existe_protocolo(editais):
     if (len(editais) > 1):
         str_editais = ', '.join(str(edital['numero']) for edital in editais)
         raise serializers.ValidationError(

--- a/sme_terceirizadas/dieta_especial/api/validators.py
+++ b/sme_terceirizadas/dieta_especial/api/validators.py
@@ -34,6 +34,14 @@ def somente_digitos(codigo_eol):
         raise serializers.ValidationError('Deve ter somente dígitos')
 
 
+def edital_ja_existe_protocolo(editais: str):
+    if (len(editais) > 1):
+        str_editais = ', '.join(str(edital['numero']) for edital in editais)
+        raise serializers.ValidationError(
+            f'Já existe um protocolo padrão com esse nome para os editais: {str_editais}.')
+    raise serializers.ValidationError('Já existe um protocolo padrão com esse nome.')
+
+
 class AlunoSerializerValidator(serializers.Serializer):
     codigo_eol = serializers.CharField(max_length=7, validators=[somente_digitos])
     nome = serializers.CharField(max_length=100)

--- a/sme_terceirizadas/dieta_especial/managers.py
+++ b/sme_terceirizadas/dieta_especial/managers.py
@@ -1,7 +1,16 @@
 from django.db import models
+from django.db.models import Q
 
 
 class AlimentoProprioManager(models.Manager):
 
     def get_queryset(self):
         return super(AlimentoProprioManager, self).get_queryset().filter(tipo='P')
+
+
+class EditalManager(models.Manager):
+    def check_editais_already_has_nome_protocolo(self, editais, nome_protocolo):
+        return self.filter(
+            Q(uuid__in=editais),
+            Q(protocolos_padroes_dieta_especial__nome_protocolo__iexact=nome_protocolo)
+        ).values('numero').distinct()

--- a/sme_terceirizadas/terceirizada/models.py
+++ b/sme_terceirizadas/terceirizada/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.db.models import Q
 from django_prometheus.models import ExportModelOperationsMixin
 
+from sme_terceirizadas.dieta_especial.managers import EditalManager
+
 from ..cardapio.models import AlteracaoCardapio, AlteracaoCardapioCEI, GrupoSuspensaoAlimentacao, InversaoCardapio
 from ..dados_comuns.behaviors import (
     Ativavel,
@@ -30,6 +32,8 @@ class Edital(ExportModelOperationsMixin('edital'), TemChaveExterna):
     processo = models.CharField('Processo Administrativo', max_length=100,
                                 help_text='Processo administrativo do edital')
     objeto = models.TextField('objeto resumido')
+
+    objects = EditalManager()
 
     @property
     def contratos(self):


### PR DESCRIPTION
# Este PR: 

- Alteração da regra para permitir a criação do nome do protocolo que já existe em edital diferente;
- Validação no _create_ e _update_ referente a existência do mesmo nome;
- Criação do manager EditalManager, para facilitar nos testes unitários;
- Tests: Validators, Urls e Manager

### Referência Azure: 
- 76330