### PR TITLE
Feature/79708-GA-kit-lanche-e-alteração-alimentação-cemei-ajustes-faixas-etárias

### DIFF
--- a/sme_terceirizadas/escola/api/viewsets.py
+++ b/sme_terceirizadas/escola/api/viewsets.py
@@ -270,6 +270,7 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
                 'faixa_etaria': FaixaEtariaSerializer(FaixaEtaria.objects.get(uuid=uuid_faixa_etaria)).data,
                 'count': faixa_alunos[uuid_faixa_etaria]
             })
+        results = sorted(results, key=lambda x: x['faixa_etaria']['inicio'])
 
         return Response({
             'count': len(results),

--- a/sme_terceirizadas/escola/models.py
+++ b/sme_terceirizadas/escola/models.py
@@ -453,7 +453,9 @@ class Escola(ExportModelOperationsMixin('escola'), Ativavel, TemChaveExterna, Te
             for uuid_, quantidade_alunos in dict_faixas.items():
                 lista_faixas[periodo].append({'uuid': uuid_,
                                               'faixa': FaixaEtaria.objects.get(uuid=uuid_).__str__(),
-                                              'quantidade_alunos': quantidade_alunos})
+                                              'quantidade_alunos': quantidade_alunos,
+                                              'inicio': FaixaEtaria.objects.get(uuid=uuid_).inicio})
+            lista_faixas[periodo] = sorted(lista_faixas[periodo], key=lambda x: x['inicio'])
         periodos = self.periodos_escolares_com_alunos
         if manha_e_tarde_sempre:
             periodos = list(PeriodoEscolar.objects.filter(nome__in=PERIODOS_ESPECIAIS_CEMEI).values_list(


### PR DESCRIPTION
# Proposta

Este PR visa ordenar por campo 'inicio' faixas etárias utilizadas nas solicitações de Alteração de Alimentação e Kit Lanche Passeio CEMEI

# Referência do Azure

- 79708

# Tarefas para concluir

- [x] ordenar por campo 'inicio' faixas etárias utilizadas na solicitação de Alteração de Alimentação CEMEI
- [x] ordenar por campo 'inicio' faixas etárias utilizadas na solicitação de Kit Lanche Passeio CEMEI