### PR TITLE
Feature/85719-PeD-tela-ativar-suspender-produto-resultado-filtro-e-relatório

### DIFF
--- a/sme_terceirizadas/produto/api/serializers/serializers.py
+++ b/sme_terceirizadas/produto/api/serializers/serializers.py
@@ -572,14 +572,15 @@ class ProdutoListagemSerializer(serializers.ModelSerializer):
     fabricante = FabricanteSerializer()
     id_externo = serializers.CharField()
     ultima_homologacao = HomologacaoListagemSerializer()
-    vinculos_produto_edital = serializers.SerializerMethodField()
+    vinculos_produto_edital_ativos = serializers.SerializerMethodField()
+    vinculos_produto_edital_suspensos = serializers.SerializerMethodField()
 
-    def get_vinculos_produto_edital(self, obj):
-        editais = obj.vinculos.all()
-        if self.context.get('status') and self.context['status'] == ['CODAE_SUSPENDEU']:
-            editais = editais.filter(suspenso=True)
-        else:
-            editais = editais.filter(suspenso=False)
+    def get_vinculos_produto_edital_ativos(self, obj):
+        editais = obj.vinculos.filter(suspenso=False)
+        return ', '.join(editais.values_list('edital__numero', flat=True))
+
+    def get_vinculos_produto_edital_suspensos(self, obj):
+        editais = obj.vinculos.filter(suspenso=True)
         return ', '.join(editais.values_list('edital__numero', flat=True))
 
     class Meta:

--- a/sme_terceirizadas/produto/api/viewsets.py
+++ b/sme_terceirizadas/produto/api/viewsets.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import datetime
 from itertools import chain
 
@@ -1080,8 +1081,23 @@ class ProdutoViewSet(viewsets.ModelViewSet):
         filter_status = request.query_params.getlist('status')
         if filter_status:
             if filter_status == ['CODAE_SUSPENDEU']:
-                queryset = queryset.filter(homologacao__status__in=['CODAE_SUSPENDEU', 'CODAE_HOMOLOGADO'],
-                                           vinculos__suspenso=True).distinct()
+                suspensos = queryset.filter(homologacao__status='CODAE_SUSPENDEU').distinct()
+                parcialmente_suspensos_status_homologado = queryset.filter(
+                    homologacao__status='CODAE_HOMOLOGADO',
+                    vinculos__suspenso=True
+                ).distinct()
+                queryset = parcialmente_suspensos_status_homologado | suspensos
+            elif Counter(filter_status) == Counter(['CODAE_SUSPENDEU', 'CODAE_HOMOLOGADO']):
+                homologados = [q for q in queryset.filter(homologacao__status='CODAE_HOMOLOGADO').distinct()]
+                suspensos = [q for q in queryset.filter(homologacao__status='CODAE_SUSPENDEU').distinct()]
+                parcialmente_suspensos_status_homologado = [
+                    q for q in queryset.filter(
+                        homologacao__status='CODAE_HOMOLOGADO',
+                        vinculos__suspenso=True
+                    ).distinct()
+                ]
+                queryset = homologados + suspensos + parcialmente_suspensos_status_homologado
+                queryset = sorted(queryset, key=lambda prod: prod.criado_em)
             else:
                 queryset = queryset.filter(homologacao__status__in=filter_status)
         page = self.paginate_queryset(queryset)


### PR DESCRIPTION
**### Este PR visa:**

- ajustar endpoint para filtrar e retornar produtos "parcialmente suspensos" com status de homologado
- enviar vinculos de produto_edital ativos e suspensos

**Referência:**
85719