### PR TITLE
feature/92380-PeD-relatorio-produtos-suspensos-trazer-produtos-suspensos-parcialmente

### DIFF
--- a/sme_terceirizadas/produto/api/serializers/serializers.py
+++ b/sme_terceirizadas/produto/api/serializers/serializers.py
@@ -485,7 +485,7 @@ class HomologacaoProdutoPainelGerencialSerializer(HomologacaoProdutoBase):
             editais = ', '.join(
                 obj.produto.vinculos.filter(suspenso=False).values_list('edital__numero', flat=True)
             )
-        if workflow == 'CODAE_SUSPENDEU':
+        if workflow in ['CODAE_SUSPENDEU', 'CODAE_AUTORIZOU_RECLAMACAO']:
             editais = ', '.join(
                 obj.produto.vinculos.filter(suspenso=True).values_list('edital__numero', flat=True)
             )


### PR DESCRIPTION
### **Este PR:**

- Adiciona produtos suspensos por motivo de 'CODAE_AUTORIZOU_RECLAMACAO' no card de suspensos
- Suspende todos os editais quando Codae autoriza reclamação
- Criado script para preencher banco com editais suspensos quando codae autoriza reclamacao

**Referência:**
92380