### PR TITLE
feature/90436-disponizalizar-relatorios-solicitacoes-alimentacao-UEs

### DIFF
--- a/sme_terceirizadas/escola/api/serializers.py
+++ b/sme_terceirizadas/escola/api/serializers.py
@@ -234,6 +234,7 @@ class LoteSimplesSerializer(serializers.ModelSerializer):
 
 
 class EscolaSimplesSerializer(serializers.ModelSerializer):
+    tipo_unidade = TipoUnidadeEscolarSerializer()
     lote = LoteNomeSerializer()
     tipo_gestao = TipoGestaoSerializer()
     periodos_escolares = PeriodoEscolarSerializer(many=True)
@@ -245,6 +246,7 @@ class EscolaSimplesSerializer(serializers.ModelSerializer):
             'uuid',
             'nome',
             'codigo_eol',
+            'tipo_unidade',
             'quantidade_alunos',
             'quantidade_alunos_cei_da_cemei',
             'quantidade_alunos_emei_da_cemei',


### PR DESCRIPTION
### **Este PR:**

- Adiciona o atributo tipo_unidade no serializer
- Cria função filtrar_solicitacoes_para_relatorio no viewset
- filtrar_solicitacoes_ga no viewset
- exportar_xlsx no viewset
- exportar_pdf no viewset
- Retira os # noqa C901 de todas as funções de exportar excel e pdf do viewset de paineis_consolidades
- Cria a função de get_recebidas no modelo de paineis consolidados
- Cria a função map_queryset_por_status no modelo de paineis consolidados

**Referência:**
90436