### PR TITLE
Feature/91848-MI-envio-de-email-para-ue-sobre-aprovação-da-medição-pela-dre

### DIFF
--- a/sme_terceirizadas/dados_comuns/templates/medicao_dre_aprova_solicitacao.html
+++ b/sme_terceirizadas/dados_comuns/templates/medicao_dre_aprova_solicitacao.html
@@ -1,0 +1,10 @@
+{% extends 'email_base.html' %}
+{% load email_templatetags %}
+
+{% block conteudo %}
+  <p>
+    A Medição Inicial referente à <strong>{{ mes }} / {{ ano }}</strong> foi aprovada pela DRE.
+  </p>
+  <br/><p><a href="{{ url }}" style="color: #198459;">Você pode acessar o sistema</a> e visualizar a Medição aprovada.</p>
+  <br/>
+{% endblock %}


### PR DESCRIPTION
**### Este PR visa:**

- enviar email para escola após DRE aprovar solicitação de medição inicial
- criar template de email de solicitação de medição aprovada pela DRE

**Referência:**
91848