### PR TITLE
Feature: disparar e-mail para escola ao solicitar correção da medição

### DIFF
--- a/sme_terceirizadas/dados_comuns/templates/medicao_dre_solicita_correcao.html
+++ b/sme_terceirizadas/dados_comuns/templates/medicao_dre_solicita_correcao.html
@@ -1,0 +1,10 @@
+{% extends 'email_base.html' %}
+{% load email_templatetags %}
+
+{% block conteudo %}
+  <p>
+    Há solicitações de correção da Medição Inicial enviadas pela DRE referente ao período <strong>{{ mes }} / {{ ano }}</strong>. Acesse o sistema e realize as correções com urgência.
+  </p>
+  <br/><p><a href="{{ url }}" style="color: #198459;">Você pode acessar o sistema</a> e visualizar a Medição aprovada.</p>
+  <br/>
+{% endblock %}


### PR DESCRIPTION
# Proposta

Este PR visa enviar e-mail informativo para Escola alertando que existem correções a serem feitas quando o usuário DRE solicitar correção da medião inicial.

# Referência do Azure

- 91842

# Tarefas para concluir

- [x] adicionar disparo de e-mail ao hook
- [x] criar template e-mail para solicitar correção