### PR TITLE
feature/91849-medicao-inicial-historico-formulario-ocorrencias

### DIFF
--- a/sme_terceirizadas/medicao_inicial/api/serializers.py
+++ b/sme_terceirizadas/medicao_inicial/api/serializers.py
@@ -3,7 +3,10 @@ import datetime
 import environ
 from rest_framework import serializers
 
-from sme_terceirizadas.dados_comuns.api.serializers import LogSolicitacoesUsuarioSerializer
+from sme_terceirizadas.dados_comuns.api.serializers import (
+    LogSolicitacoesUsuarioComAnexosSerializer,
+    LogSolicitacoesUsuarioSerializer
+)
 from sme_terceirizadas.dados_comuns.utils import converte_numero_em_mes
 from sme_terceirizadas.escola.api.serializers import TipoUnidadeEscolarSerializer
 from sme_terceirizadas.medicao_inicial.models import (
@@ -29,7 +32,7 @@ class DiaSobremesaDoceSerializer(serializers.ModelSerializer):
 
 
 class OcorrenciaMedicaoInicialSerializer(serializers.ModelSerializer):
-    logs = LogSolicitacoesUsuarioSerializer(many=True)
+    logs = LogSolicitacoesUsuarioComAnexosSerializer(many=True)
     ultimo_arquivo = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
 


### PR DESCRIPTION
# Proposta

Colocar botão histórico de ocorrência nas ocorrências de medição inicial.

# Referência do Azure

- 91849

# Tarefas para concluir

- [x] Altera serializer da ocorrência para que venha com os anexos nos logs