### PR TITLE
feature/85716-PeD-definicao-edital-produto-suspenso-reclamacao

### DIFF
--- a/sme_terceirizadas/dados_comuns/constants.py
+++ b/sme_terceirizadas/dados_comuns/constants.py
@@ -139,6 +139,7 @@ CODAE_QUESTIONA_NUTRISUPERVISOR = 'codae-questiona-nutrisupervisor'
 CODAE_RESPONDE = 'codae-responde'
 CODAE_CANCELA_SOLICITACAO_CORRECAO = 'codae-cancela-solicitacao-correcao'
 TERCEIRIZADA_CANCELA_SOLICITACAO_CORRECAO = 'terceirizada-cancela-solicitacao-correcao'
+VINCULOS_ATIVOS_PRODUTO_EDITAL = 'vinculos-ativos-produto-edital'
 
 TERCEIRIZADA_RESPONDE_QUESTIONAMENTO = 'terceirizada-responde-questionamento'
 TERCEIRIZADA_TOMOU_CIENCIA = 'terceirizada-toma-ciencia'

--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -1413,10 +1413,18 @@ class FluxoHomologacaoProduto(xwf_models.WorkflowEnabled, models.Model):
     def _codae_recusou_reclamacao_hook(self, *args, **kwargs):
         user = kwargs['user']
         justificativa = kwargs.get('justificativa', '')
-        self.salvar_log_transicao(
-            status_evento=LogSolicitacoesUsuario.CODAE_RECUSOU_RECLAMACAO,
-            justificativa=justificativa,
-            usuario=user)
+
+        if kwargs['suspensao_parcial']:
+            self.salva_log_com_justificativa_e_anexos(
+                LogSolicitacoesUsuario.SUSPENSO_EM_ALGUNS_EDITAIS,
+                kwargs['request'],
+                justificativa
+            )
+        else:
+            self.salvar_log_transicao(
+                status_evento=LogSolicitacoesUsuario.CODAE_RECUSOU_RECLAMACAO,
+                justificativa=justificativa,
+                usuario=user)
 
     @xworkflows.after_transition('terceirizada_inativa')
     def _inativa_homologacao_hook(self, *args, **kwargs):
@@ -2784,6 +2792,7 @@ class ReclamacaoProdutoWorkflow(xwf_models.Workflow):
                           AGUARDANDO_ANALISE_SENSORIAL,
                           ANALISE_SENSORIAL_RESPONDIDA,
                           AGUARDANDO_RESPOSTA_UE,
+                          AGUARDANDO_RESPOSTA_NUTRISUPERVISOR,
                           RESPONDIDO_UE], CODAE_RECUSOU),
         ('codae_responde', [AGUARDANDO_AVALIACAO,
                             ANALISE_SENSORIAL_RESPONDIDA,

--- a/sme_terceirizadas/produto/api/serializers/serializers.py
+++ b/sme_terceirizadas/produto/api/serializers/serializers.py
@@ -831,6 +831,22 @@ class ProdutoSuspensoSerializer(ProdutoBaseSerializer):
                   'ultima_homologacao', 'criado_em', 'vinculos_produto_edital')
 
 
+class VinculosProdutosEditalAtivosSerializer(ProdutoBaseSerializer):
+    vinculos_produto_edital = serializers.SerializerMethodField()
+
+    def get_vinculos_produto_edital(self, obj):
+        return ProdutoEditalSerializer(
+            ProdutoEdital.objects.filter(
+                produto=obj,
+                suspenso=False
+            ), many=True
+        ).data
+
+    class Meta:
+        model = Produto
+        fields = ('vinculos_produto_edital',)
+
+
 class ItensCadastroSerializer(serializers.ModelSerializer):
     nome = serializers.SerializerMethodField()
     tipo_display = serializers.SerializerMethodField()


### PR DESCRIPTION
# Proposta

Este PR visa selecionar os editais a serem suspensos para produtos com reclamações parcialmente aceitas

# Referência do Azure

- 85716

# Tarefas para concluir

- [x] Altera salvamento de log para quando codae recusa reclamacao
- [x] Altera viewset de codae recusa
- [x] diminui complexidade de das viewsets codae aceita e codae recusa
- [x] criar seriealizer vinculos de produtos e editais ativos
