### PR TITLE
bugfix/97190-data-homologacao-relatorio-homologados

### DIFF
--- a/sme_terceirizadas/produto/models.py
+++ b/sme_terceirizadas/produto/models.py
@@ -155,7 +155,7 @@ class Produto(Ativavel, CriadoEm, CriadoPor, Nomeavel, TemChaveExterna, TemIdent
                 homologacao.logs
                 .filter(status_evento=LogSolicitacoesUsuario.CODAE_HOMOLOGADO)
                 .order_by('criado_em')
-                .last())
+                .first())
             return log_homologacao.criado_em if log_homologacao else None
         except HomologacaoProduto.DoesNotExist:
             return ''


### PR DESCRIPTION
# Proposta

Este PR visa exibir a data de homologação mais antiga dos produtos no relatório de produtos homologados

# Referência do Azure

- 97190

# Tarefas para concluir

- [x] Mudar a ordem de coleta da data de homologação