### PR TITLE
Feature/97570-GA-modal-observação-na-autorização-inclusão-alimentação-codae

### DIFF
--- a/sme_terceirizadas/inclusao_alimentacao/api/viewsets.py
+++ b/sme_terceirizadas/inclusao_alimentacao/api/viewsets.py
@@ -132,7 +132,7 @@ class CodaeAutoriza():
         justificativa = request.data.get('justificativa', '')
         try:
             if obj.status == obj.workflow_class.DRE_VALIDADO:
-                obj.codae_autoriza(user=request.user)
+                obj.codae_autoriza(user=request.user, justificativa=justificativa)
             else:
                 obj.codae_autoriza_questionamento(
                     user=request.user, justificativa=justificativa)

--- a/sme_terceirizadas/relatorios/templates/bloco_historico_questionamento_com_data.html
+++ b/sme_terceirizadas/relatorios/templates/bloco_historico_questionamento_com_data.html
@@ -3,7 +3,7 @@
 {% block historico_questionamento %}
     {% if solicitacao.logs.all|tem_questionamentos %}
       <div class="question-history">
-        <h5 class="title">Histórico de questionamento</h5>
+        <h4 class="title">Histórico de questionamento</h4>
         <div class='question-log'>
             {% for log in solicitacao.logs.all %}
                 {% if log.status_evento_explicacao == "Questionamento pela CODAE" %}
@@ -14,7 +14,7 @@
                       previstos no contrato?
                     </div>
                     <div class="obs mb-3">
-                      Observação da CODAE: {{ log.justificativa | observacao_padrao:"CODAE" | safe }}
+                      Observação da CODAE: <br> {{ log.justificativa | observacao_padrao:"CODAE" | safe }}
                     </div>
                   </div>
                 {% endif %}
@@ -22,22 +22,31 @@
                   <div class="is-it-possible">
                     {{log.criado_em|date:"d/m/Y H:i:s"}} - TERCEIRIZADA <br>
                     <div class="title">
-                        {{ log.resposta_sim_nao |aceita_nao_aceita_str }}
+                        {{ log.resposta_sim_nao | aceita_nao_aceita_str }}
                     </div>
                     <div class="obs mb-3">
-                      Observação da Terceirizada: {{ log.justificativa |observacao_padrao:"Terceirizada" | safe }}
+                      Observação da Terceirizada: <br> {{ log.justificativa | observacao_padrao:"Terceirizada" | safe }}
                     </div>
                   </div>
                 {% endif %}
                 {% if log.status_evento_explicacao == "CODAE autorizou" %}
                   <div class="is-it-possible">
-                    {{log.criado_em|date:"d/m/Y H:i:s"}} - CODAE <br>
-                    <div class="title">Autorizou</div>
-                      {% if log.justificativa %}
-                        <div class="obs">
-                          Observação da CODAE: {{ log.justificativa | safe }}
-                        </div>
-                      {% endif %}
+                    {% if solicitacao|eh_inclusao %}
+                      <div class="title">Autorizou</div>
+                      {{log.criado_em|date:"d/m/Y H:i:s"}} - Informações da CODAE <br>
+                    {% else %}
+                      {{log.criado_em|date:"d/m/Y H:i:s"}} - CODAE <br>
+                      <div class="title">Autorizou</div>
+                    {% endif %}
+                    {% if solicitacao|eh_inclusao %}
+                      <div class="obs">
+                        {{ log.justificativa | observacao_padrao:"CODAE" | safe }}
+                      </div>
+                    {% else %}
+                      <div class="obs">
+                        Observação da CODAE: {{ log.justificativa | safe }}
+                      </div>
+                    {% endif %}
                   </div>
                 {% endif %}
                 {% if log.status_evento_explicacao == "CODAE negou" %}

--- a/sme_terceirizadas/relatorios/templates/bloco_observacao_codae_autoriza.html
+++ b/sme_terceirizadas/relatorios/templates/bloco_observacao_codae_autoriza.html
@@ -9,7 +9,7 @@
             <p class="cabecalho mb-2"><b>Autorizou</b></p>
             <div>{{ log.criado_em|date:"d/m/Y H:i:s" }} - Informações da CODAE</div>
             <div class="mt-2 justificativa-cancelamento-escola-dre">
-              {{ log.justificativa }}
+              {{ log.justificativa | observacao_padrao:"CODAE" | safe }}
             </div>
           {% endif %}
         {% endfor %}

--- a/sme_terceirizadas/relatorios/templates/novo_solicitacao_inclusao_alimentacao_cei.html
+++ b/sme_terceirizadas/relatorios/templates/novo_solicitacao_inclusao_alimentacao_cei.html
@@ -195,10 +195,15 @@
 
 <div class="mx-4 my-2">
   {% include "bloco_observacoes.html" %}
-  {% include "bloco_historico_questionamento.html" %}
+  <div class="conteudo">
+    {% include "bloco_historico_questionamento_com_data.html" %}
+  </div>
   {% include "bloco_historico_cancelamento_inclusao.html" %}
   {% if solicitacao.status == 'ESCOLA_CANCELOU' %}
     {% include "bloco_historico_cancelamento.html" %}
   {% endif %}
+  <div class="conteudo">
+    {% include "bloco_observacao_codae_autoriza.html" %}
+  </div>
 </div>
 {% endblock %}

--- a/sme_terceirizadas/relatorios/templates/solicitacao_inclusao_alimentacao_cemei.html
+++ b/sme_terceirizadas/relatorios/templates/solicitacao_inclusao_alimentacao_cemei.html
@@ -234,8 +234,16 @@
     {% endif %}
   </div>
   <div class="row mx-5" style="font-size: 14px;">
-    <hr style="color: #EEEEEE; opacity: 0.3">
-    {% include "bloco_historico_questionamento_com_data.html" %}
+    <div class="conteudo">
+      {% include "bloco_historico_questionamento_com_data.html" %}
+    </div>
   </div>
 {% endif %}
+
+<div class="row mx-3">
+  <div class="conteudo">
+    {% include "bloco_observacao_codae_autoriza.html" %}
+  </div>
+</div>
+
 {% endblock %}

--- a/sme_terceirizadas/relatorios/templates/solicitacao_inclusao_alimentacao_continua.html
+++ b/sme_terceirizadas/relatorios/templates/solicitacao_inclusao_alimentacao_continua.html
@@ -68,10 +68,11 @@
       </table>
     </div>
       {% include "bloco_observacoes.html" %}
-      {% include "bloco_historico_questionamento.html" %}
+      {% include "bloco_historico_questionamento_com_data.html" %}
       {% include "bloco_historico_cancelamento_inclusao.html" %}
       {% if solicitacao.status == 'ESCOLA_CANCELOU' %}
         {% include "bloco_historico_cancelamento.html" %}
       {% endif %}
+      {% include "bloco_observacao_codae_autoriza.html" %}
   </div>
 {% endblock %}

--- a/sme_terceirizadas/relatorios/templates/solicitacao_inclusao_alimentacao_normal.html
+++ b/sme_terceirizadas/relatorios/templates/solicitacao_inclusao_alimentacao_normal.html
@@ -52,9 +52,10 @@
     </div>
       {% include "bloco_observacoes.html" %}
       {% include "bloco_historico_cancelamento_inclusao.html" %}
-      {% include "bloco_historico_questionamento.html" %}
+      {% include "bloco_historico_questionamento_com_data.html" %}
       {% if solicitacao.status == 'ESCOLA_CANCELOU' %}
         {% include "bloco_historico_cancelamento.html" %}
       {% endif %}
+      {% include "bloco_observacao_codae_autoriza.html" %}
   </div>
 {% endblock %}

--- a/sme_terceirizadas/relatorios/templatetags/index.py
+++ b/sme_terceirizadas/relatorios/templatetags/index.py
@@ -6,6 +6,12 @@ from django import template
 from ...dados_comuns import constants
 from ...dados_comuns.fluxo_status import DietaEspecialWorkflow
 from ...dados_comuns.models import LogSolicitacoesUsuario
+from ...inclusao_alimentacao.models import (
+    GrupoInclusaoAlimentacaoNormal,
+    InclusaoAlimentacaoContinua,
+    InclusaoAlimentacaoDaCEI,
+    InclusaoDeAlimentacaoCEMEI
+)
 
 register = template.Library()
 
@@ -294,7 +300,17 @@ def existe_inclusao_cancelada(solicitacao):
     status_ = solicitacao['status'] if isinstance(solicitacao, dict) else solicitacao.status
     inclusoes_ = solicitacao['datas_intervalo'] if isinstance(solicitacao, dict) else solicitacao.inclusoes
     return (status_ == 'ESCOLA_CANCELOU' or
-            inclusoes_.filter(cancelado_justificativa__isnull=False).exists())
+            inclusoes_.filter(cancelado_justificativa__isnull=False).exclude(cancelado_justificativa='').exists())
+
+
+@register.filter
+def eh_inclusao(solicitacao):
+    return (
+        isinstance(solicitacao, GrupoInclusaoAlimentacaoNormal) or
+        isinstance(solicitacao, InclusaoAlimentacaoContinua) or
+        isinstance(solicitacao, InclusaoAlimentacaoDaCEI) or
+        isinstance(solicitacao, InclusaoDeAlimentacaoCEMEI)
+    )
 
 
 @register.filter


### PR DESCRIPTION
**### Este PR visa:**

- incluir bloco_observacao_codae_autoriza e ajustar bloco de histórico de questionamento
- incluir justificativa quando codae autoriza
- ajustar template bloco_observacao_codae_autoriza, ajustar template bloco_historico_questionamento_com_data

**Referência:**
97570