### PR TITLE
Feature/93436-MI-aprovação-medição-inicial-pela-codae

### DIFF
--- a/sme_terceirizadas/medicao_inicial/__tests__/conftest.py
+++ b/sme_terceirizadas/medicao_inicial/__tests__/conftest.py
@@ -75,6 +75,9 @@ def solicitacao_medicao_inicial(escola, categoria_medicao):
 
 @pytest.fixture
 def solicitacao_medicao_inicial_medicao_enviada_pela_ue(solicitacao_medicao_inicial):
+    for medicao in solicitacao_medicao_inicial.medicoes.all():
+        medicao.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_APROVADA_PELA_DRE
+        medicao.save()
     solicitacao_medicao_inicial.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_ENVIADA_PELA_UE
     solicitacao_medicao_inicial.save()
     return solicitacao_medicao_inicial
@@ -83,6 +86,43 @@ def solicitacao_medicao_inicial_medicao_enviada_pela_ue(solicitacao_medicao_inic
 @pytest.fixture
 def solicitacao_medicao_inicial_medicao_correcao_solicitada(solicitacao_medicao_inicial):
     solicitacao_medicao_inicial.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_CORRECAO_SOLICITADA
+    solicitacao_medicao_inicial.save()
+    return solicitacao_medicao_inicial
+
+
+@pytest.fixture
+def solicitacao_medicao_inicial_medicao_aprovada_pela_dre_ok(solicitacao_medicao_inicial):
+    for medicao in solicitacao_medicao_inicial.medicoes.all():
+        medicao.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_APROVADA_PELA_CODAE
+        medicao.save()
+    solicitacao_medicao_inicial.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_APROVADA_PELA_DRE
+    solicitacao_medicao_inicial.save()
+    return solicitacao_medicao_inicial
+
+
+@pytest.fixture
+def solicitacao_medicao_inicial_medicao_aprovada_pela_dre_nok(solicitacao_medicao_inicial):
+    solicitacao_medicao_inicial.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_APROVADA_PELA_DRE
+    solicitacao_medicao_inicial.save()
+    return solicitacao_medicao_inicial
+
+
+@pytest.fixture
+def solicitacao_medicao_inicial_medicao_enviada_pela_ue_nok(solicitacao_medicao_inicial):
+    for medicao in solicitacao_medicao_inicial.medicoes.all():
+        medicao.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_APROVADA_PELA_CODAE
+        medicao.save()
+    solicitacao_medicao_inicial.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_ENVIADA_PELA_UE
+    solicitacao_medicao_inicial.save()
+    return solicitacao_medicao_inicial
+
+
+@pytest.fixture
+def solicitacao_medicao_inicial_medicao_enviada_pela_ue_nok__2(solicitacao_medicao_inicial):
+    for medicao in solicitacao_medicao_inicial.medicoes.all():
+        medicao.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_APROVADA_PELA_DRE
+        medicao.save()
+    solicitacao_medicao_inicial.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_EM_ABERTO_PARA_PREENCHIMENTO_UE
     solicitacao_medicao_inicial.save()
     return solicitacao_medicao_inicial
 
@@ -324,8 +364,7 @@ def client_autenticado_da_escola(client, django_user_model, escola):
     password = 'admin@123'
     perfil_diretor = mommy.make('Perfil', nome='DIRETOR_UE', ativo=True)
     usuario = django_user_model.objects.create_user(username=email, password=password, email=email,
-                                                    registro_funcional='123456',
-                                                    )
+                                                    registro_funcional='123456')
     hoje = datetime.date.today()
     mommy.make('Vinculo', usuario=usuario, instituicao=escola, perfil=perfil_diretor,
                data_inicial=hoje, ativo=True)
@@ -339,10 +378,28 @@ def client_autenticado_adm_da_escola(client, django_user_model, escola):
     password = 'admin@1234'
     perfil_diretor = mommy.make('Perfil', nome='ADMINISTRADOR_UE', ativo=True)
     usuario = django_user_model.objects.create_user(username=email, password=password, email=email,
-                                                    registro_funcional='1234567',
-                                                    )
+                                                    registro_funcional='1234567')
     hoje = datetime.date.today()
     mommy.make('Vinculo', usuario=usuario, instituicao=escola, perfil=perfil_diretor,
                data_inicial=hoje, ativo=True)
+    client.login(username=email, password=password)
+    return client
+
+
+@pytest.fixture
+def client_autenticado_codae_medicao(client, django_user_model):
+    email = 'codae@medicao.com'
+    password = 'admin@1234'
+    perfil_medicao = mommy.make('Perfil', nome='ADMINISTRADOR_MEDICAO', ativo=True)
+    usuario = django_user_model.objects.create_user(username=email, password=password, email=email,
+                                                    registro_funcional='1234588')
+    codae = mommy.make('Codae')
+    hoje = datetime.date.today()
+    mommy.make('Vinculo',
+               usuario=usuario,
+               instituicao=codae,
+               perfil=perfil_medicao,
+               data_inicial=hoje,
+               ativo=True)
     client.login(username=email, password=password)
     return client

--- a/sme_terceirizadas/medicao_inicial/__tests__/conftest.py
+++ b/sme_terceirizadas/medicao_inicial/__tests__/conftest.py
@@ -122,7 +122,8 @@ def solicitacao_medicao_inicial_medicao_enviada_pela_ue_nok__2(solicitacao_medic
     for medicao in solicitacao_medicao_inicial.medicoes.all():
         medicao.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_APROVADA_PELA_DRE
         medicao.save()
-    solicitacao_medicao_inicial.status = solicitacao_medicao_inicial.workflow_class.MEDICAO_EM_ABERTO_PARA_PREENCHIMENTO_UE
+    status = solicitacao_medicao_inicial.workflow_class.MEDICAO_EM_ABERTO_PARA_PREENCHIMENTO_UE
+    solicitacao_medicao_inicial.status = status
     solicitacao_medicao_inicial.save()
     return solicitacao_medicao_inicial
 

--- a/sme_terceirizadas/medicao_inicial/__tests__/test_urls.py
+++ b/sme_terceirizadas/medicao_inicial/__tests__/test_urls.py
@@ -489,13 +489,14 @@ def test_url_dre_aprova_solicitacao_medicao_erro_pendencias(client_autenticado_d
         f'dre-aprova-solicitacao-medicao/'
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == {'detail': "Erro: existe(m) pendência(s) de análise"}
+    assert response.json() == {'detail': 'Erro: existe(m) pendência(s) de análise'}
 
 
 def test_url_dre_aprova_solicitacao_medicao_erro_transicao(client_autenticado_diretoria_regional,
                                                            solicitacao_medicao_inicial_medicao_enviada_pela_ue_nok__2):
     response = client_autenticado_diretoria_regional.patch(
-        f'/medicao-inicial/solicitacao-medicao-inicial/{solicitacao_medicao_inicial_medicao_enviada_pela_ue_nok__2.uuid}/'
+        f'/medicao-inicial/solicitacao-medicao-inicial/'
+        f'{solicitacao_medicao_inicial_medicao_enviada_pela_ue_nok__2.uuid}/'
         f'dre-aprova-solicitacao-medicao/'
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
**### Este PR visa:**

- criar endpoint codae-aprova-solicitacao-medicao
- criar transição codae_aprova_medicao
- criar testes unitários para endpoints codae-aprova-solicitacao-medicao e re-aprova-solicitacao-medicao

**Referência:**
93436