### PR TITLE
feature/99208-PeD-Alteracao-modal-ativacao-produto

### DIFF
--- a/sme_terceirizadas/produto/__tests__/conftest.py
+++ b/sme_terceirizadas/produto/__tests__/conftest.py
@@ -607,3 +607,10 @@ def item_cadastrado_4(embalagem_produto):
 @pytest.fixture
 def usuario():
     return mommy.make('perfil.Usuario')
+
+
+@pytest.fixture
+def homologacao_produto_suspenso(homologacao_produto):
+    homologacao_produto.status = HomologacaoProdutoWorkflow.CODAE_SUSPENDEU
+    homologacao_produto.save()
+    return homologacao_produto


### PR DESCRIPTION
# Proposta

Este PR visa trazer todos os editais quando for ativação de produto.

# Referência do Azure

- 99208

# Tarefas para concluir

- [x] Altera função ativar para criar vinculo com edital caso não tenha
- [x] Cria teste unitário para função ativa

