### PR TITLE
Feature/99127-MI-ocorrências-e-períodos-devolvidos-para-ajustes-pela-codae-visão-ue

### DIFF
--- a/sme_terceirizadas/dados_comuns/fluxo_status.py
+++ b/sme_terceirizadas/dados_comuns/fluxo_status.py
@@ -3048,6 +3048,10 @@ class SolicitacaoMedicaoInicialWorkflow(xwf_models.Workflow):
                                      MEDICAO_APROVADA_PELA_DRE,
                                      MEDICAO_CORRIGIDA_PARA_CODAE], MEDICAO_APROVADA_PELA_CODAE),
         ('ue_corrige', [MEDICAO_CORRECAO_SOLICITADA, MEDICAO_CORRIGIDA_PELA_UE], MEDICAO_CORRIGIDA_PELA_UE),
+        ('ue_corrige_ocorrencia_para_codae', [MEDICAO_CORRECAO_SOLICITADA_CODAE,
+                                              MEDICAO_CORRIGIDA_PARA_CODAE], MEDICAO_CORRIGIDA_PARA_CODAE),
+        ('ue_corrige_periodo_grupo_para_codae', [MEDICAO_CORRECAO_SOLICITADA_CODAE,
+                                                 MEDICAO_CORRIGIDA_PARA_CODAE], MEDICAO_CORRIGIDA_PARA_CODAE),
         ('ue_corrige_medicao_para_codae', MEDICAO_CORRECAO_SOLICITADA_CODAE, MEDICAO_CORRIGIDA_PARA_CODAE),
         ('dre_aprova', [MEDICAO_ENVIADA_PELA_UE, MEDICAO_CORRECAO_SOLICITADA,
                         MEDICAO_CORRIGIDA_PELA_UE], MEDICAO_APROVADA_PELA_DRE),
@@ -3309,6 +3313,44 @@ class FluxoSolicitacaoMedicaoInicial(xwf_models.WorkflowEnabled, models.Model):
                 self.salvar_log_transicao(status_evento=status,
                                           usuario=user,
                                           justificativa=justificativa)
+
+    @xworkflows.after_transition('ue_corrige_ocorrencia_para_codae')
+    def _ue_corrige_ocorrencia_para_codae_hook(self, *args, **kwargs):
+        from ..medicao_inicial.models import OcorrenciaMedicaoInicial
+        user = kwargs['user']
+        justificativa = kwargs.get('justificativa', '')
+        if user and isinstance(self, OcorrenciaMedicaoInicial):
+            if not user.vinculo_atual.perfil.nome == DIRETOR_UE:
+                raise PermissionDenied(f'Você não tem permissão para executar essa ação.')
+
+            status = LogSolicitacoesUsuario.MEDICAO_CORRIGIDA_PARA_CODAE
+
+            log_antigo = self.logs.filter(status_evento=status)
+
+            if log_antigo:
+                log_antigo = log_antigo.first()
+                log_antigo.anexos.all().delete()
+                log_antigo.delete()
+
+            log_transicao = self.salvar_log_transicao(status_evento=status,
+                                                      usuario=user,
+                                                      justificativa=justificativa)
+            for anexo in kwargs.get('anexos', []):
+                arquivo = convert_base64_to_contentfile(anexo.pop('base64'))
+                AnexoLogSolicitacoesUsuario.objects.create(
+                    log=log_transicao,
+                    arquivo=arquivo,
+                    nome=anexo['nome']
+                )
+
+    @xworkflows.after_transition('ue_corrige_periodo_grupo_para_codae')
+    def _ue_corrige_periodo_grupo_para_codae_hook(self, *args, **kwargs):
+        user = kwargs['user']
+        if user:
+            if not user.vinculo_atual.perfil.nome == DIRETOR_UE:
+                raise PermissionDenied(f'Você não tem permissão para executar essa ação.')
+            self.salvar_log_transicao(status_evento=LogSolicitacoesUsuario.MEDICAO_CORRIGIDA_PARA_CODAE,
+                                      usuario=user)
 
     @xworkflows.after_transition('ue_corrige_medicao_para_codae')
     def _ue_corrige_medicao_para_codae_hook(self, *args, **kwargs):

--- a/sme_terceirizadas/medicao_inicial/__tests__/conftest.py
+++ b/sme_terceirizadas/medicao_inicial/__tests__/conftest.py
@@ -305,7 +305,18 @@ def anexo_ocorrencia_medicao_inicial_status_inicial():
 
 
 @pytest.fixture
-def sol_med_inicial_devolvida_para_ue():
+def anexo_ocorrencia_medicao_inicial_status_aprovado_pela_dre():
+    nome = 'arquivo_teste.pdf'
+    arquivo = SimpleUploadedFile(f'arquivo_teste.pdf', bytes('CONTENT', encoding='utf-8'))
+    solicitacao_medicao = mommy.make('SolicitacaoMedicaoInicial')
+    return mommy.make('OcorrenciaMedicaoInicial', uuid='2bed204b-2c1c-4686-b5e3-60a922ad0e1a',
+                      nome_ultimo_arquivo=nome, ultimo_arquivo=arquivo,
+                      solicitacao_medicao_inicial=solicitacao_medicao,
+                      status='MEDICAO_APROVADO_PELA_DRE')
+
+
+@pytest.fixture
+def sol_med_inicial_devolvida_pela_dre_para_ue():
     nome = 'arquivo_teste.pdf'
     arquivo = SimpleUploadedFile(f'arquivo_teste.pdf', bytes('CONTENT', encoding='utf-8'))
     solicitacao = mommy.make('SolicitacaoMedicaoInicial', status='MEDICAO_CORRECAO_SOLICITADA',
@@ -314,6 +325,19 @@ def sol_med_inicial_devolvida_para_ue():
                nome_ultimo_arquivo=nome, ultimo_arquivo=arquivo,
                solicitacao_medicao_inicial=solicitacao,
                status='MEDICAO_CORRECAO_SOLICITADA')
+    return solicitacao
+
+
+@pytest.fixture
+def sol_med_inicial_devolvida_pela_codae_para_ue():
+    nome = 'arquivo_teste.pdf'
+    arquivo = SimpleUploadedFile(f'arquivo_teste.pdf', bytes('CONTENT', encoding='utf-8'))
+    solicitacao = mommy.make('SolicitacaoMedicaoInicial', status='MEDICAO_CORRECAO_SOLICITADA_CODAE',
+                             uuid='d9de8653-4910-423e-9381-e391c2ae8ecb', com_ocorrencias=True)
+    mommy.make('OcorrenciaMedicaoInicial', uuid='ea7299a3-3eb6-4858-a7b4-387446c607a1',
+               nome_ultimo_arquivo=nome, ultimo_arquivo=arquivo,
+               solicitacao_medicao_inicial=solicitacao,
+               status='MEDICAO_CORRECAO_SOLICITADA_CODAE')
     return solicitacao
 
 

--- a/sme_terceirizadas/medicao_inicial/api/viewsets.py
+++ b/sme_terceirizadas/medicao_inicial/api/viewsets.py
@@ -21,7 +21,6 @@ from ...dados_comuns.permissions import (
     UsuarioEscolaTercTotal,
     ViewSetActionPermissionMixin
 )
-from ...dados_comuns.utils import convert_base64_to_contentfile
 from ...escola.api.permissions import PodeCriarAdministradoresDaCODAEGestaoAlimentacaoTerceirizada
 from ...escola.models import Escola
 from ..models import (
@@ -34,7 +33,7 @@ from ..models import (
     ValorMedicao
 )
 from ..tasks import gera_pdf_relatorio_solicitacao_medicao_por_escola_async
-from ..utils import tratar_valores
+from ..utils import atualizar_anexos_ocorrencia, atualizar_status_ocorrencia, tratar_valores
 from .permissions import EhAdministradorMedicaoInicialOuGestaoAlimentacao
 from .serializers import (
     CategoriaMedicaoSerializer,
@@ -446,6 +445,8 @@ class SolicitacaoMedicaoInicialViewSet(
     @action(detail=True, methods=['PATCH'], url_path='ue-atualiza-ocorrencia',)
     def ue_atualiza_ocorrencia(self, request, uuid=None):
         solicitacao_medicao_inicial = self.get_object()
+        status_ocorrencia = solicitacao_medicao_inicial.status
+        status_correcao_solicitada_codae = SolicitacaoMedicaoInicial.workflow_class.MEDICAO_CORRECAO_SOLICITADA_CODAE
         try:
             anexos_string = request.data.get('anexos', None)
             com_ocorrencias = request.data.get('com_ocorrencias', None)
@@ -453,18 +454,24 @@ class SolicitacaoMedicaoInicialViewSet(
             if com_ocorrencias == 'true' and anexos_string:
                 solicitacao_medicao_inicial.com_ocorrencias = True
                 anexos = json.loads(anexos_string)
-                for anexo in anexos:
-                    if '.pdf' in anexo['nome']:
-                        arquivo = convert_base64_to_contentfile(anexo['base64'])
-                        solicitacao_medicao_inicial.ocorrencia.ultimo_arquivo = arquivo
-                        solicitacao_medicao_inicial.ocorrencia.nome_ultimo_arquivo = anexo.get('nome')
-                        solicitacao_medicao_inicial.ocorrencia.save()
-                solicitacao_medicao_inicial.ocorrencia.ue_corrige(user=request.user,
-                                                                  anexos=anexos,
-                                                                  justificativa=justificativa)
+                atualizar_anexos_ocorrencia(anexos, solicitacao_medicao_inicial)
+                if status_ocorrencia == status_correcao_solicitada_codae:
+                    solicitacao_medicao_inicial.ocorrencia.ue_corrige_ocorrencia_para_codae(user=request.user,
+                                                                                            anexos=anexos,
+                                                                                            justificativa=justificativa)
+                else:
+                    solicitacao_medicao_inicial.ocorrencia.ue_corrige(user=request.user,
+                                                                      anexos=anexos,
+                                                                      justificativa=justificativa)
             else:
                 solicitacao_medicao_inicial.com_ocorrencias = False
-                solicitacao_medicao_inicial.ocorrencia.ue_corrige(user=request.user, justificativa=justificativa)
+                atualizar_status_ocorrencia(
+                    status_ocorrencia,
+                    status_correcao_solicitada_codae,
+                    solicitacao_medicao_inicial,
+                    request,
+                    justificativa
+                )
             solicitacao_medicao_inicial.save()
             serializer = self.get_serializer(solicitacao_medicao_inicial)
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -597,6 +604,8 @@ class MedicaoViewSet(
             permission_classes=[UsuarioDiretorEscolaTercTotal])
     def escola_corrige_medicao(self, request, uuid=None):
         medicao = self.get_object()
+        status_correcao_solicitada_codae = SolicitacaoMedicaoInicial.workflow_class.MEDICAO_CORRECAO_SOLICITADA_CODAE
+        status_medicao_corrigida_para_codae = SolicitacaoMedicaoInicial.workflow_class.MEDICAO_CORRIGIDA_PARA_CODAE
         try:
             for valor_medicao in request.data:
                 ValorMedicao.objects.filter(
@@ -605,7 +614,10 @@ class MedicaoViewSet(
                     nome_campo=valor_medicao.get('nome_campo', ''),
                     categoria_medicao=valor_medicao.get('categoria_medicao', '')
                 ).update(valor=valor_medicao.get('valor', ''))
-            medicao.ue_corrige(user=request.user)
+            if medicao.status in [status_correcao_solicitada_codae, status_medicao_corrigida_para_codae]:
+                medicao.ue_corrige_periodo_grupo_para_codae(user=request.user)
+            else:
+                medicao.ue_corrige(user=request.user)
             serializer = self.get_serializer(medicao)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except InvalidTransitionError as e:

--- a/sme_terceirizadas/paineis_consolidados/api/viewsets.py
+++ b/sme_terceirizadas/paineis_consolidados/api/viewsets.py
@@ -921,7 +921,8 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         return_dict = []
 
         def append(dia, inclusao):
-            return_dict.append(formata_resultado_inclusoes_etec_autorizadas(dia, mes, ano, inclusao))
+            resultado = formata_resultado_inclusoes_etec_autorizadas(dia, mes, ano, inclusao)
+            return_dict.append(resultado) if resultado else None
 
         for sol_escola in query_set:
             inclusao = sol_escola.get_raw_model.objects.get(uuid=sol_escola.uuid)


### PR DESCRIPTION
**### Este PR visa:**

- criar transitions ue_corrige_ocorrencia_para_codae e ue_corrige_periodo_grupo_para_codae
- ajuste endpoint inclusoes_etec_autorizadas
- criar testes para transitions ue_corrige_ocorrencia_para_codae e ue_corrige_periodo_grupo_para_codae

**Referência:**
99127