### PR TITLE
Feature/108489 calendario cronogramas pre recebimento

### DIFF
--- a/sme_terceirizadas/conftest.py
+++ b/sme_terceirizadas/conftest.py
@@ -13,6 +13,7 @@ from .inclusao_alimentacao.models import (
 )
 from .pre_recebimento.fixtures.factories.cronograma_factory import (
     CronogramaFactory,
+    EtapasDoCronogramaFactory,
     LaboratorioFactory,
     UnidadeMedidaFactory,
 )
@@ -44,6 +45,7 @@ register(ProdutoLogisticaFactory)
 register(ProdutoTerceirizadaFactory)
 register(TipoDeDocumentoDeRecebimentoFactory)
 register(UnidadeMedidaFactory)
+register(EtapasDoCronogramaFactory)
 
 
 @pytest.fixture

--- a/sme_terceirizadas/dados_comuns/permissions.py
+++ b/sme_terceirizadas/dados_comuns/permissions.py
@@ -722,6 +722,27 @@ class PermissaoParaDashboardCronograma(BasePermission):
         )
 
 
+class PermissaoParaVisualizarCalendarioCronograma(BasePermission):
+    PERFIS_PERMITIDOS = [
+        DILOG_CRONOGRAMA,
+        DILOG_QUALIDADE,
+        COORDENADOR_CODAE_DILOG_LOGISTICA,
+    ]
+
+    def has_permission(self, request, view):
+        usuario = request.user
+        return (
+            not usuario.is_anonymous
+            and usuario.vinculo_atual
+            and (
+                (
+                    isinstance(usuario.vinculo_atual.instituicao, Codae)
+                    and usuario.vinculo_atual.perfil.nome in self.PERFIS_PERMITIDOS
+                )
+            )
+        )
+
+
 class PermissaoParaDashboardLayoutEmbalagem(BasePermission):
     PERFIS_PERMITIDOS = [
         COORDENADOR_CODAE_DILOG_LOGISTICA,

--- a/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
+++ b/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
@@ -2823,8 +2823,6 @@ def test_calendario_cronograma_list_ok(
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["count"] == len(etapas_cronogramas)
 
-    breakpoint()
-
 
 def test_calendario_cronograma_list_not_authorized(client_autenticado):
     """Deve retornar status HTTP 403 ao tentar obter listagem com usuário não autorizado."""

--- a/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
+++ b/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
@@ -1253,8 +1253,7 @@ def test_url_dashboard_layout_embalagens_status_retornados(
 
     assert response.status_code == status.HTTP_200_OK
 
-    user_id = client_autenticado_codae_dilog.session["_auth_user_id"]
-    user = get_user_model().objects.get(id=user_id)
+    user = get_user_model().objects.get()
     status_esperados = ServiceDashboardLayoutEmbalagem.get_dashboard_status(user)
     status_recebidos = [result["status"] for result in response.json()["results"]]
 
@@ -2072,8 +2071,7 @@ def test_url_documentos_de_recebimento_listagem_not_authorized(client_autenticad
 def test_url_dashboard_documentos_de_recebimento_status_retornados(
     client_autenticado_codae_dilog, documento_de_recebimento_factory
 ):
-    user_id = client_autenticado_codae_dilog.session["_auth_user_id"]
-    user = get_user_model().objects.get(id=user_id)
+    user = get_user_model().objects.get()
     status_esperados = ServiceDashboardDocumentosDeRecebimento.get_dashboard_status(
         user
     )

--- a/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
+++ b/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
@@ -1253,7 +1253,8 @@ def test_url_dashboard_layout_embalagens_status_retornados(
 
     assert response.status_code == status.HTTP_200_OK
 
-    user = get_user_model().objects.get()
+    user_id = client_autenticado_codae_dilog.session["_auth_user_id"]
+    user = get_user_model().objects.get(id=user_id)
     status_esperados = ServiceDashboardLayoutEmbalagem.get_dashboard_status(user)
     status_recebidos = [result["status"] for result in response.json()["results"]]
 
@@ -2071,7 +2072,8 @@ def test_url_documentos_de_recebimento_listagem_not_authorized(client_autenticad
 def test_url_dashboard_documentos_de_recebimento_status_retornados(
     client_autenticado_codae_dilog, documento_de_recebimento_factory
 ):
-    user = get_user_model().objects.get()
+    user_id = client_autenticado_codae_dilog.session["_auth_user_id"]
+    user = get_user_model().objects.get(id=user_id)
     status_esperados = ServiceDashboardDocumentosDeRecebimento.get_dashboard_status(
         user
     )

--- a/sme_terceirizadas/pre_recebimento/__tests__/test_validators.py
+++ b/sme_terceirizadas/pre_recebimento/__tests__/test_validators.py
@@ -1,7 +1,7 @@
 import pytest
 from rest_framework.serializers import ValidationError
 
-from ..api.validators import contrato_pertence_a_empresa
+from ..api.validators import contrato_pertence_a_empresa, valida_parametros_calendario
 
 pytestmark = pytest.mark.django_db
 
@@ -16,3 +16,20 @@ def test_contrato_pertence_a_empresa_validator(contrato, empresa):
         ValidationError, match="Contrato deve pertencer a empresa selecionada"
     ):
         contrato_pertence_a_empresa(contrato, empresa)
+
+
+def test_valida_parametros_calendario_validator():
+    with pytest.raises(ValidationError):
+        valida_parametros_calendario(None, "2023")
+
+    with pytest.raises(ValidationError):
+        valida_parametros_calendario("a", "2023")
+
+    with pytest.raises(ValidationError):
+        valida_parametros_calendario("0", "2023")
+
+    with pytest.raises(ValidationError):
+        valida_parametros_calendario("13", "2023")
+
+    with pytest.raises(ValidationError):
+        valida_parametros_calendario("5", "23")

--- a/sme_terceirizadas/pre_recebimento/api/serializers/serializers.py
+++ b/sme_terceirizadas/pre_recebimento/api/serializers/serializers.py
@@ -69,6 +69,44 @@ class EtapasDoCronogramaSerializer(serializers.ModelSerializer):
         )
 
 
+class EtapasDoCronogramaCalendarioSerializer(serializers.ModelSerializer):
+    nome_produto = serializers.SerializerMethodField()
+    uuid_cronograma = serializers.SerializerMethodField()
+    numero_cronograma = serializers.SerializerMethodField()
+    nome_fornecedor = serializers.SerializerMethodField()
+    data_programada = serializers.SerializerMethodField()
+
+    def get_nome_produto(self, obj):
+        return obj.cronograma.produto.nome if obj.cronograma.produto else None
+
+    def get_uuid_cronograma(self, obj):
+        return obj.cronograma.uuid if obj.cronograma else None
+
+    def get_numero_cronograma(self, obj):
+        return str(obj.cronograma.numero) if obj.cronograma else None
+
+    def get_nome_fornecedor(self, obj):
+        return obj.cronograma.empresa.nome_fantasia if obj.cronograma.empresa else None
+
+    def get_data_programada(self, obj):
+        return obj.data_programada.strftime("%d/%m/%Y") if obj.data_programada else None
+
+    class Meta:
+        model = EtapasDoCronograma
+        fields = (
+            "uuid",
+            "nome_produto",
+            "uuid_cronograma",
+            "numero_cronograma",
+            "nome_fornecedor",
+            "data_programada",
+            "numero_empenho",
+            "etapa",
+            "parte",
+            "quantidade",
+        )
+
+
 class SolicitacaoAlteracaoCronogramaSerializer(serializers.ModelSerializer):
     fornecedor = serializers.CharField(source="cronograma.empresa")
     cronograma = serializers.CharField(source="cronograma.numero")

--- a/sme_terceirizadas/pre_recebimento/api/validators.py
+++ b/sme_terceirizadas/pre_recebimento/api/validators.py
@@ -7,3 +7,29 @@ def contrato_pertence_a_empresa(contrato, empresa):
             "Contrato deve pertencer a empresa selecionada"
         )
     return True
+
+
+def valida_parametros_calendario(mes, ano):
+    if not (mes and ano):
+        raise serializers.ValidationError(
+            "Os parâmetros mes e ano são parametros obrigatórios"
+        )
+
+    try:
+        mes = int(mes)
+        ano = int(ano)
+
+    except ValueError:
+        raise serializers.ValidationError(
+            "Os parâmetros mes e ano devem ser números inteiros."
+        )
+
+    if not (1 <= mes <= 12):
+        raise serializers.ValidationError(
+            "Informe um mês valido, deve ser um número inteiro entre 1 e 12"
+        )
+
+    if len(str(ano)) != 4:
+        raise serializers.ValidationError(
+            "Informe um ano valido, deve ser um número inteiro de 4 dígitos (Ex.: 2023)"
+        )

--- a/sme_terceirizadas/pre_recebimento/fixtures/factories/cronograma_factory.py
+++ b/sme_terceirizadas/pre_recebimento/fixtures/factories/cronograma_factory.py
@@ -3,6 +3,7 @@ from faker import Faker
 
 from sme_terceirizadas.pre_recebimento.models import (
     Cronograma,
+    EtapasDoCronograma,
     Laboratorio,
     UnidadeMedida,
 )
@@ -43,3 +44,10 @@ class UnidadeMedidaFactory(DjangoModelFactory):
 
     abreviacao = Sequence(lambda n: fake.unique.pystr(min_chars=3, max_chars=3).upper())
     nome = Sequence(lambda n: f"Laboratorio {fake.unique.name()}")
+
+
+class EtapasDoCronogramaFactory(DjangoModelFactory):
+    class Meta:
+        model = EtapasDoCronograma
+
+    cronograma = SubFactory(CronogramaFactory)

--- a/sme_terceirizadas/pre_recebimento/urls.py
+++ b/sme_terceirizadas/pre_recebimento/urls.py
@@ -27,6 +27,11 @@ router.register(
 )
 router.register("rascunho-ficha-tecnica", viewsets.FichaTecnicaRascunhoViewSet)
 router.register("ficha-tecnica", viewsets.FichaTecnicaModelViewSet)
+router.register(
+    "calendario-cronogramas",
+    viewsets.CalendarioCronogramaViewset,
+    basename="calendario-cronogramas",
+)
 
 
 urlpatterns = [path("", include(router.urls))]


### PR DESCRIPTION
# Este PR:

- Cria serializer de leitura para o modelo EtapasDoCronograma;
- Cria validator para os parâmetros mês e ano, recebidos do frontend;
- Cria permissão para acesso ao Calendário de Cronogramas;
- Cria e registra viewset para fornecer acesso ao calendário;
- Cria factory básica para o modelo EtapasDoCronograma;
- Cria testes automatizados.

### Referência Azure:

- 108489