### PR TITLE
Hotfix/111180 ordenacao relatorio pdf solicitacoes alimentacao

### DIFF
--- a/sme_terceirizadas/paineis_consolidados/api/viewsets.py
+++ b/sme_terceirizadas/paineis_consolidados/api/viewsets.py
@@ -244,7 +244,7 @@ class SolicitacoesViewSet(viewsets.ReadOnlyModelViewSet):
         filtros = {
             key: value for key, value in map_filtros.items() if value not in [None, []]
         }
-        queryset = queryset.filter(**filtros)
+        queryset = queryset.filter(**filtros).order_by("escola_nome")
         queryset = self.remove_duplicados_do_query_set(queryset)
         return queryset
 

--- a/sme_terceirizadas/paineis_consolidados/tasks.py
+++ b/sme_terceirizadas/paineis_consolidados/tasks.py
@@ -485,8 +485,7 @@ def gera_pdf_relatorio_solicitacoes_alimentacao_async(
 
     try:
         instituicao = Usuario.objects.get(username=user).vinculo_atual.instituicao
-        solicitacoes = SolicitacoesCODAE.objects.filter(uuid__in=uuids)
-        solicitacoes = solicitacoes.order_by(
+        solicitacoes = SolicitacoesCODAE.objects.filter(uuid__in=uuids).order_by(
             "lote_nome", "escola_nome", "terceirizada_nome"
         )
         solicitacoes = set(
@@ -503,6 +502,13 @@ def gera_pdf_relatorio_solicitacoes_alimentacao_async(
                     instituicao,
                 )
             )
+        lista_solicitacoes_dict = sorted(
+            lista_solicitacoes_dict,
+            key=lambda solicitacao_: (
+                solicitacao_["lote"],
+                solicitacao_["unidade_educacional"],
+            ),
+        )
         arquivo = build_pdf(lista_solicitacoes_dict, status)
         atualiza_central_download(obj_central_download, nome_arquivo, arquivo)
     except Exception as e:


### PR DESCRIPTION
# Este PR:
- corrige a ordanação do relatório PDF de solicitações de alimentação

### Referência azure:
- 111180