### PR TITLE
Fix/111230-TEC-corrigir-task-logs-dietas-autorizadas-escolas-cemei

### DIFF
--- a/sme_terceirizadas/dados_comuns/__tests__/conftest.py
+++ b/sme_terceirizadas/dados_comuns/__tests__/conftest.py
@@ -8,6 +8,7 @@ from model_mommy import mommy
 from sme_terceirizadas.dieta_especial.models import (
     ClassificacaoDieta,
     LogQuantidadeDietasAutorizadas,
+    LogQuantidadeDietasAutorizadasCEI,
 )
 
 from ...escola import models
@@ -522,3 +523,102 @@ def logs_quantidade_dietas_autorizadas_escola_comum(escola, periodo_escolar):
         periodo_escolar=periodo_escolar,
     )
     return LogQuantidadeDietasAutorizadas.objects.all()
+
+
+@pytest.fixture
+def escola_cemei():
+    terceirizada = mommy.make("Terceirizada")
+    lote = mommy.make("Lote", terceirizada=terceirizada)
+    diretoria_regional = mommy.make(
+        "DiretoriaRegional", nome="DIRETORIA REGIONAL TESTE"
+    )
+    tipo_gestao = mommy.make("TipoGestao", nome="TERC TOTAL")
+    tipo_unidade_escolar = mommy.make("TipoUnidadeEscolar", iniciais="CEMEI")
+    return mommy.make(
+        "Escola",
+        nome="CEMEI TESTE",
+        lote=lote,
+        diretoria_regional=diretoria_regional,
+        tipo_gestao=tipo_gestao,
+        tipo_unidade=tipo_unidade_escolar,
+    )
+
+
+@pytest.fixture
+def faixas_etarias_ativas():
+    faixas = [
+        (0, 1),
+        (1, 4),
+        (4, 6),
+        (6, 8),
+        (8, 12),
+        (12, 24),
+        (24, 48),
+        (48, 72),
+    ]
+    return [
+        mommy.make("FaixaEtaria", inicio=inicio, fim=fim, ativo=True)
+        for (inicio, fim) in faixas
+    ]
+
+
+@pytest.fixture
+def logs_quantidade_dietas_autorizadas_escola_cei(
+    escola_cei, periodo_escolar, faixas_etarias_ativas
+):
+    hoje = datetime.date.today()
+    ontem = hoje - datetime.timedelta(days=1)
+    quatro_dias_atras = hoje - datetime.timedelta(days=4)
+    quantidades = [15, 15]
+    classificacao = mommy.make(ClassificacaoDieta, nome="Tipo B")
+    for quantidade in quantidades:
+        mommy.make(
+            LogQuantidadeDietasAutorizadasCEI,
+            quantidade=quantidade,
+            escola=escola_cei,
+            data=ontem,
+            classificacao=classificacao,
+            periodo_escolar=periodo_escolar,
+            faixa_etaria=faixas_etarias_ativas[0],
+        )
+    mommy.make(
+        LogQuantidadeDietasAutorizadasCEI,
+        quantidade=50,
+        escola=escola_cei,
+        data=quatro_dias_atras,
+        classificacao=classificacao,
+        periodo_escolar=periodo_escolar,
+        faixa_etaria=faixas_etarias_ativas[0],
+    )
+    return LogQuantidadeDietasAutorizadasCEI.objects.all()
+
+
+@pytest.fixture
+def logs_quantidade_dietas_autorizadas_escola_cemei(
+    escola_cemei, periodo_escolar, faixas_etarias_ativas
+):
+    hoje = datetime.date.today()
+    dois_dias_atras = hoje - datetime.timedelta(days=2)
+    quatro_dias_atras = hoje - datetime.timedelta(days=5)
+    quantidades = [25, 25]
+    classificacao = mommy.make(ClassificacaoDieta, nome="Tipo C")
+    for quantidade in quantidades:
+        mommy.make(
+            LogQuantidadeDietasAutorizadasCEI,
+            quantidade=quantidade,
+            escola=escola_cemei,
+            data=dois_dias_atras,
+            classificacao=classificacao,
+            periodo_escolar=periodo_escolar,
+            faixa_etaria=faixas_etarias_ativas[2],
+        )
+    mommy.make(
+        LogQuantidadeDietasAutorizadasCEI,
+        quantidade=50,
+        escola=escola_cemei,
+        data=quatro_dias_atras,
+        classificacao=classificacao,
+        periodo_escolar=periodo_escolar,
+        faixa_etaria=faixas_etarias_ativas[2],
+    )
+    return LogQuantidadeDietasAutorizadasCEI.objects.all()

--- a/sme_terceirizadas/dados_comuns/__tests__/test_utils.py
+++ b/sme_terceirizadas/dados_comuns/__tests__/test_utils.py
@@ -3,7 +3,10 @@ from datetime import date
 import environ
 from freezegun import freeze_time
 
-from sme_terceirizadas.dieta_especial.models import LogQuantidadeDietasAutorizadas
+from sme_terceirizadas.dieta_especial.models import (
+    LogQuantidadeDietasAutorizadas,
+    LogQuantidadeDietasAutorizadasCEI,
+)
 from sme_terceirizadas.escola.models import LogAlunosMatriculadosPeriodoEscola
 
 from ..constants import (
@@ -137,7 +140,21 @@ def test_analisa_logs_alunos_matriculados_periodo_escola(
 
 def test_analisa_logs_quantidade_dietas_autorizadas(
     logs_quantidade_dietas_autorizadas_escola_comum,
+    logs_quantidade_dietas_autorizadas_escola_cei,
+    logs_quantidade_dietas_autorizadas_escola_cemei,
 ):
     analisa_logs_quantidade_dietas_autorizadas()
-    logs = LogQuantidadeDietasAutorizadas.objects.all()
-    assert logs.count() == 3
+    logs_dietas_comuns = LogQuantidadeDietasAutorizadas.objects.all()
+    assert logs_dietas_comuns.count() == 3
+    logs_dietas_cei = [
+        log
+        for log in LogQuantidadeDietasAutorizadasCEI.objects.all()
+        if log.escola.tipo_unidade.iniciais == "CEI DIRET"
+    ]
+    assert len(logs_dietas_cei) == 4
+    logs_dietas_cemei = [
+        log
+        for log in LogQuantidadeDietasAutorizadasCEI.objects.all()
+        if log.escola.tipo_unidade.iniciais == "CEMEI"
+    ]
+    assert len(logs_dietas_cemei) == 5

--- a/sme_terceirizadas/dados_comuns/utils.py
+++ b/sme_terceirizadas/dados_comuns/utils.py
@@ -594,7 +594,10 @@ def create_objects_logs(escola, log_para_criar, data):
         LogQuantidadeDietasAutorizadasCEI,
     )
 
-    if escola.eh_cei:
+    if escola.eh_cei or (
+        escola.eh_cemei
+        and log_para_criar._meta.model.__name__ == "LogQuantidadeDietasAutorizadasCEI"
+    ):
         LogQuantidadeDietasAutorizadasCEI.objects.create(
             quantidade=log_para_criar.quantidade,
             escola=log_para_criar.escola,


### PR DESCRIPTION
**### Este PR visa:**

- ajusta função create_objects_logs para criar logs corretamente de escolas CEMEI
- cria testes unitários de logs dietas para escolas CEI e CEMEI

**Referência:**
111230