### PR TITLE
Hotfix/112086 erro editar dieta

### DIFF
--- a/sme_terceirizadas/dieta_especial/api/serializers.py
+++ b/sme_terceirizadas/dieta_especial/api/serializers.py
@@ -172,6 +172,8 @@ class SolicitacaoDietaEspecialAutorizarSerializer(
         if data_termino:
             data_termino = datetime.strptime(data_termino, "%Y-%m-%d").date()
             instance.data_termino = data_termino
+        else:
+            instance.data_termino = None
 
         instance.alergias_intolerancias.clear()
 


### PR DESCRIPTION
# Este PR:
- corrige erro ao salvar/atualizar dieta especial sem data termino

### Referência azure:
- AB#112086