### PR TITLE
Feature/106417 - Conferência Lançamentos - Nutrimanifestacao e Codae

### DIFF
--- a/sme_terceirizadas/escola/api/viewsets.py
+++ b/sme_terceirizadas/escola/api/viewsets.py
@@ -19,7 +19,9 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ModelViewSet, ReadOnlyModelViewSet
 
 from ...dados_comuns.permissions import (
+    UsuarioCODAEDietaEspecial,
     UsuarioCODAEGestaoAlimentacao,
+    UsuarioCODAENutriManifestacao,
     UsuarioDiretoriaRegional,
     UsuarioEscolaTercTotal,
     ViewSetActionPermissionMixin,
@@ -302,6 +304,8 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
             UsuarioEscolaTercTotal
             | UsuarioDiretoriaRegional
             | UsuarioCODAEGestaoAlimentacao
+            | UsuarioCODAEDietaEspecial
+            | UsuarioCODAENutriManifestacao
         ],
     )
     def inclusao_continua_por_mes(self, request):


### PR DESCRIPTION
# Este PR: 
- Adiciona permissão para qualquer usuário Codae e Nutrimanifestacao acessar a tela de conferência de lançamentos da Medição Inicial.

### Referência azure:
- 106417