### PR TITLE
Feature/113173 incluir novos perfis na visualização de calendário

### DIFF
--- a/sme_terceirizadas/dados_comuns/permissions.py
+++ b/sme_terceirizadas/dados_comuns/permissions.py
@@ -743,6 +743,8 @@ class PermissaoParaVisualizarCalendarioCronograma(BasePermission):
         DILOG_CRONOGRAMA,
         DILOG_QUALIDADE,
         COORDENADOR_CODAE_DILOG_LOGISTICA,
+        DINUTRE_DIRETORIA,
+        DILOG_DIRETORIA,
     ]
 
     def has_permission(self, request, view):


### PR DESCRIPTION
# Este PR:

-  adiciona permissão de acesso ao calendário de cronogramas para os perfis DINUTRE_DIRETORIA e DILOG_DIRETORIA

### Referência Azure:
- 113173