### PR TITLE
Feature/114786 liberacao de painel de docs de recebimento para novos perfis

### DIFF
--- a/sme_terceirizadas/dados_comuns/permissions.py
+++ b/sme_terceirizadas/dados_comuns/permissions.py
@@ -786,6 +786,7 @@ class PermissaoParaDashboardDocumentosDeRecebimento(BasePermission):
     PERFIS_PERMITIDOS = [
         DILOG_QUALIDADE,
         COORDENADOR_CODAE_DILOG_LOGISTICA,
+        DILOG_CRONOGRAMA,
     ]
 
     def has_permission(self, request, view):
@@ -1114,6 +1115,8 @@ class PermissaoParaVisualizarLayoutDeEmbalagem(BasePermission):
 class PermissaoParaVisualizarDocumentosDeRecebimento(BasePermission):
     PERFIS_PERMITIDOS = [
         DILOG_QUALIDADE,
+        COORDENADOR_CODAE_DILOG_LOGISTICA,
+        DILOG_CRONOGRAMA,
     ]
 
     def has_permission(self, request, view):

--- a/sme_terceirizadas/pre_recebimento/api/services.py
+++ b/sme_terceirizadas/pre_recebimento/api/services.py
@@ -186,6 +186,11 @@ class ServiceDashboardDocumentosDeRecebimento(BaseServiceDashboard):
             DocumentoDeRecebimentoWorkflow.APROVADO,
             DocumentoDeRecebimentoWorkflow.ENVIADO_PARA_CORRECAO,
         ],
+        DILOG_CRONOGRAMA: [
+            DocumentoDeRecebimentoWorkflow.ENVIADO_PARA_ANALISE,
+            DocumentoDeRecebimentoWorkflow.APROVADO,
+            DocumentoDeRecebimentoWorkflow.ENVIADO_PARA_CORRECAO,
+        ],
     }
 
 


### PR DESCRIPTION
# Este PR:

- libera o painel de documentos de recebimento para os perfis COORDENADOR_CODAE_DILOG_LOGISTICA e DILOG_CRONOGRAMA;

### Referência Azure:
- 114786