### PR TITLE
feat(122234): Ajusta campos obrigatórios para produtos não perecíveis

### DIFF
--- a/sme_terceirizadas/pre_recebimento/__tests__/conftest.py
+++ b/sme_terceirizadas/pre_recebimento/__tests__/conftest.py
@@ -840,10 +840,6 @@ def payload_ficha_tecnica_nao_pereciveis(
         "unidade_medida_volume_primaria": str(unidade_medida_logistica.uuid),
     }
 
-    payload.pop("numero_registro")
-    payload.pop("agroecologico")
-    payload.pop("organico")
-    payload.pop("mecanismo_controle")
     payload.pop("prazo_validade_descongelamento")
     payload.pop("temperatura_congelamento")
     payload.pop("temperatura_veiculo")

--- a/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
+++ b/sme_terceirizadas/pre_recebimento/__tests__/test_urls.py
@@ -2942,7 +2942,14 @@ def test_ficha_tecnica_validate_nao_pereciveis(
     payload_ficha_tecnica_nao_pereciveis,
 ):
     payload = {**payload_ficha_tecnica_nao_pereciveis}
-    payload.pop("produto_eh_liquido")
+    attrs_obrigatorios_nao_pereciveis = {
+        "produto_eh_liquido",
+        "numero_registro",
+        "agroecologico",
+        "organico",
+    }
+    for attr in attrs_obrigatorios_nao_pereciveis:
+        payload.pop(attr)
 
     response = client_autenticado_fornecedor.post(
         "/ficha-tecnica/",
@@ -2952,7 +2959,7 @@ def test_ficha_tecnica_validate_nao_pereciveis(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["non_field_errors"] == [
-        "Fichas Técnicas de Produtos NÃO PERECÍVEIS exigem que sejam forncecidos valores para o campo produto_eh_liquido"
+        "Fichas Técnicas de Produtos NÃO PERECÍVEIS exigem que sejam forncecidos valores para os campos numero_registro, agroecologico, organico, e produto_eh_liquido"
     ]
 
     # testa validação dos atributos volume_embalagem_primaria e unidade_medida_volume_primaria

--- a/sme_terceirizadas/pre_recebimento/api/validators.py
+++ b/sme_terceirizadas/pre_recebimento/api/validators.py
@@ -62,9 +62,17 @@ def valida_campos_pereciveis_ficha_tecnica(attrs):
 
 
 def valida_campos_nao_pereciveis_ficha_tecnica(attrs):
-    if attrs.get("produto_eh_liquido") is None:
+    attrs_obrigatorios_pereciveis = {
+        "numero_registro",
+        "agroecologico",
+        "organico",
+        "produto_eh_liquido"
+    }
+
+    if not attrs_obrigatorios_pereciveis.issubset(attrs.keys()):
         raise serializers.ValidationError(
-            "Fichas Técnicas de Produtos NÃO PERECÍVEIS exigem que sejam forncecidos valores para o campo produto_eh_liquido"
+            "Fichas Técnicas de Produtos NÃO PERECÍVEIS exigem que sejam forncecidos valores para os campos"
+            + " numero_registro, agroecologico, organico, e produto_eh_liquido"
         )
 
 


### PR DESCRIPTION
- Adiciona numero_registro, agroecologico, organico e mecanismo_controle como campos obrigatórios para produtos não perecíveis
- Atualiza testes

História: [AB#122234](https://dev.azure.com/amcomgov/52ce043c-20b0-4d94-a252-504e3b0a0ff2/_workitems/edit/122234)