### PR TITLE
Hotfix/corrige-label-rastro-terceirizada

### DIFF
--- a/sme_sigpae_api/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers.py
+++ b/sme_sigpae_api/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers.py
@@ -19,6 +19,9 @@ from sme_sigpae_api.escola.api.serializers import (
     PeriodoEscolarSerializer,
     TipoAlimentacaoSerializer,
 )
+from sme_sigpae_api.terceirizada.api.serializers.serializers import (
+    TerceirizadaSimplesSerializer,
+)
 
 
 class FaixaEtariaSubstituicaoAlimentacaoCEMEICEISerializer(serializers.ModelSerializer):
@@ -68,6 +71,7 @@ class AlteracaoCardapioCEMEISerializer(serializers.ModelSerializer):
         SubstituicaoAlimentacaoNoPeriodoEscolarCEMEIEMEISerializer(many=True)
     )
     datas_intervalo = DatasIntervaloAlteracaoCardapioCEMEICreateSerializer(many=True)
+    rastro_terceirizada = TerceirizadaSimplesSerializer()
 
     class Meta:
         model = AlteracaoCardapioCEMEI

--- a/sme_sigpae_api/inclusao_alimentacao/api/serializers/serializers.py
+++ b/sme_sigpae_api/inclusao_alimentacao/api/serializers/serializers.py
@@ -115,6 +115,7 @@ class InclusaoAlimentacaoDaCEIBaseSerializer(serializers.ModelSerializer):
 
 class InclusaoAlimentacaoDaCEISerializer(InclusaoAlimentacaoDaCEIBaseSerializer):
     solicitacoes_similares = InclusaoAlimentacaoDaCEIBaseSerializer(many=True)
+    rastro_terceirizada = TerceirizadaSimplesSerializer()
 
 
 class QuantidadePorPeriodoSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
# Este PR:
- corrige label da empresa que deveria vir do `rastro_terceirizada` ao invés da empresa dentro do lote atual