### PR TITLE
Bugfix/corrige validacao programas projetos periodos zerados

### DIFF
--- a/src/medicao_inicial/__tests__/test_validators/test_valida_programa_projetos_com_periodos_zerados.py
+++ b/src/medicao_inicial/__tests__/test_validators/test_valida_programa_projetos_com_periodos_zerados.py
@@ -224,3 +224,78 @@ def test_com_um_periodo_nao_zero_ok(
     erros = run_validator(validator, solicitacao)
 
     assert_sem_erro(erros)
+
+
+@pytest.mark.parametrize(
+    "validator, fixture_name, categoria_fixture, periodo_nome, extra",
+    [
+        (
+            validate_solicitacoes_programas_e_projetos,
+            "solicitacao_medicao_finaliza_programas_projetos_zerados_alimentacao",
+            "categoria_medicao",
+            "TARDE",
+            None,
+        ),
+        (
+            validate_solicitacoes_programas_e_projetos,
+            "solicitacao_medicao_finaliza_programas_projetos_zerados_dietas",
+            "categoria_medicao_dieta_a",
+            "TARDE",
+            None,
+        ),
+        (
+            validate_solicitacoes_programas_e_projetos_emebs,
+            "solicitacao_medicao_finaliza_programas_projetos_zerados_emebs_alimentacao",
+            "categoria_medicao",
+            "TARDE",
+            {"infantil_ou_fundamental": "FUNDAMENTAL"},
+        ),
+        (
+            validate_solicitacoes_programas_e_projetos_emebs,
+            "solicitacao_medicao_finaliza_programas_projetos_zerados_emebs_dietas",
+            "categoria_medicao_dieta_a",
+            "TARDE",
+            {"infantil_ou_fundamental": "FUNDAMENTAL"},
+        ),
+        (
+            _validate_solicitacoes_programas_e_projetos_emei_cemei,
+            "solicitacao_medicao_finaliza_programas_projetos_zerados_cemei_alimentacao",
+            "categoria_medicao",
+            "Infantil TARDE",
+            None,
+        ),
+        (
+            _validate_solicitacoes_programas_e_projetos_emei_cemei,
+            "solicitacao_medicao_finaliza_programas_projetos_cemei_zerados_dietas",
+            "categoria_medicao_dieta_a",
+            "Infantil TARDE",
+            None,
+        ),
+    ],
+)
+def test_periodo_sem_lancamento_nao_gera_erro(
+    request, validator, fixture_name, categoria_fixture, periodo_nome, extra
+):
+    """Período sem valor lançado (None) não deve ser tratado como zero — não deve gerar erro."""
+    solicitacao = request.getfixturevalue(fixture_name)
+    categoria = request.getfixturevalue(categoria_fixture)
+
+    if solicitacao.escola.eh_cemei:
+        medicao_tarde = solicitacao.medicoes.filter(grupo__nome=periodo_nome).first()
+    else:
+        medicao_tarde = solicitacao.medicoes.filter(
+            periodo_escolar__nome=periodo_nome
+        ).first()
+
+    filtros = {
+        "nome_campo": "frequencia",
+        "dia": "14",
+        "categoria_medicao": categoria,
+    }
+    if extra:
+        filtros.update(extra)
+    medicao_tarde.valores_medicao.filter(**filtros).delete()
+
+    erros = run_validator(validator, solicitacao)
+
+    assert_sem_erro(erros)

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -3929,12 +3929,12 @@ def _all_periodos_zero(
         categoria: Instância de `CategoriaMedicao`.
 
     Returns:
-        bool: True se todos os períodos estão zero ou sem valor, False caso contrário.
+        bool: True se todos os períodos estão preenchidos com zero, False caso contrário.
     """
     for medicao in medicoes_periodos:
         key = (medicao.id, dia, categoria.id)
         valor = valores_periodos.get(key)
-        if valor is not None and valor != "0":
+        if valor is None or valor != "0":
             return False
     return True
 
@@ -4175,7 +4175,7 @@ def _programas_e_projetos_periodo_zero_emebs_necessita_erro_otimizado(
     for medicao in medicoes_periodos:
         key = (medicao.id, dia, categoria.id, infantil_ou_fundamental)
         valor = valores_periodos.get(key)
-        if valor is not None and valor != "0":
+        if valor is None or valor != "0":
             return False
 
     valor_programas = valores_programas.get(


### PR DESCRIPTION
# Este PR:
- corrige validação de programas e projetos quando os outros períodos estão zerados 
  - agora, só vale se está explicitamente com frequência zero; frequência não preenchida não conta