### PR TITLE
fix(148413): corrige criação de medições pra não criar periodo inutil

### DIFF
--- a/src/medicao_inicial/__tests__/test_models.py
+++ b/src/medicao_inicial/__tests__/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 import pytest
 from django.db.utils import IntegrityError
@@ -291,3 +292,43 @@ def test_unique_constraint_sem_recreio(escola):
         SolicitacaoMedicaoInicial.objects.create(
             escola=escola, mes="06", ano="2024",
         )
+
+
+def test_cria_medicoes_dos_periodos_passa_mes_para_periodos_escolares(
+    solicitacao_medicao_inicial_factory,
+):
+    """Verifica que cria_medicoes_dos_periodos chama periodos_escolares com ano e mes."""
+    solicitacao = solicitacao_medicao_inicial_factory(mes="03", ano="2024")
+
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    periodo_tarde = baker.make("PeriodoEscolar", nome="TARDE")
+
+    with patch.object(
+        solicitacao.escola,
+        "periodos_escolares",
+        return_value=[periodo_manha, periodo_tarde],
+    ) as mock_periodos:
+        solicitacao.cria_medicoes_dos_periodos()
+
+        # Deve chamar periodos_escolares com o mes como inteiro
+        mock_periodos.assert_called_once_with("2024", 3)
+
+        # Deve criar Medicao para cada periodo retornado
+        assert solicitacao.medicoes.count() == 2
+
+
+def test_cria_medicoes_dos_periodos_nao_cria_quando_sem_periodos(
+    solicitacao_medicao_inicial_factory,
+):
+    """Verifica que cria_medicoes_dos_periodos nao cria medicoes quando nao ha periodos."""
+    solicitacao = solicitacao_medicao_inicial_factory(mes="03", ano="2024")
+
+    with patch.object(
+        solicitacao.escola,
+        "periodos_escolares",
+        return_value=[],
+    ) as mock_periodos:
+        solicitacao.cria_medicoes_dos_periodos()
+
+        mock_periodos.assert_called_once_with("2024", 3)
+        assert solicitacao.medicoes.count() == 0

--- a/src/medicao_inicial/models.py
+++ b/src/medicao_inicial/models.py
@@ -129,7 +129,7 @@ class SolicitacaoMedicaoInicial(
         )
 
     def cria_medicoes_dos_periodos(self) -> None:
-        periodos_escolares = self.escola.periodos_escolares(self.ano)
+        periodos_escolares = self.escola.periodos_escolares(self.ano, int(self.mes))
         if not periodos_escolares:
             return
         for periodo_escolar in periodos_escolares:


### PR DESCRIPTION
Este PR:
- corrige problema na criação das mediçoes pra buscar periodos por mes e não por ano, assim nao criando periodos que possam ter sido descontinuados de mes pra mes

[AB#148413](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148413)