### PR TITLE
Feature/147505 relatorio solicitacoes alimentacao cancelamento parcial inclusao continua reflexo medicao pt2

### DIFF
--- a/src/escola/__tests__/test_urls.py
+++ b/src/escola/__tests__/test_urls.py
@@ -365,6 +365,52 @@ def test_url_endpoint_periodos_escolares_actions(client_autenticado_da_escola):
     assert response.status_code == status.HTTP_200_OK
 
 
+def test_url_endpoint_periodos_escolares_inclusao_continua_por_mes_considera_encerrado_por_quantidade_periodo(
+    client_autenticado_da_escola, escola
+):
+    client = client_autenticado_da_escola
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programa Contínuo")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    periodo_tarde = baker.make("PeriodoEscolar", nome="TARDE")
+    periodo_noite = baker.make("PeriodoEscolar", nome="NOITE")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        data_inicial=datetime.date(2026, 4, 20),
+        data_final=datetime.date(2026, 5, 31),
+        motivo=motivo,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        encerrado_a_partir_de=datetime.date(2026, 4, 30),
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_tarde,
+        encerrado_a_partir_de=datetime.date(2026, 5, 10),
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_noite,
+    )
+
+    response = client.get(
+        "/periodos-escolares/inclusao-continua-por-mes/?mes=05&ano=2026"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["periodos"] == {
+        "TARDE": str(periodo_tarde.uuid),
+        "NOITE": str(periodo_noite.uuid),
+    }
+
+
 def test_url_endpoint_diretoria_regional_simplessima_actions(
     client_autenticado_da_dre, diretoria_regional
 ):

--- a/src/escola/api/viewsets.py
+++ b/src/escola/api/viewsets.py
@@ -414,13 +414,22 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
                 )
                 .filter(
                     data_inicial__lte=ultimo_dia_mes,
-                    data_final__gte=primeiro_dia_mes,
+                )
+                .filter(
+                    Q(
+                        quantidades_por_periodo__encerrado_a_partir_de__isnull=True,
+                        data_final__gte=primeiro_dia_mes,
+                    )
+                    | Q(
+                        quantidades_por_periodo__encerrado_a_partir_de__gte=primeiro_dia_mes
+                    )
                 )
                 .exclude(motivo__nome="ETEC")
                 .values_list(
                     "quantidades_por_periodo__periodo_escolar__nome",
                     "quantidades_por_periodo__periodo_escolar__uuid",
                 )
+                .distinct()
             )
             return Response({"periodos": periodos if len(periodos) else None})
         except ValidationError as e:


### PR DESCRIPTION
# Este PR:
- altera a logica do endpoint inclusao-continua-por-mes para comportar novo campo encerrado_a_partir_de na inclusão contínua

### Referência azure:
- [AB#147505](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/147505)