### PR TITLE
Bugfix/148832 correcao documento validacao

### DIFF
--- a/src/pre_recebimento/__tests__/test_urls.py
+++ b/src/pre_recebimento/__tests__/test_urls.py
@@ -2688,7 +2688,7 @@ def test_url_documentos_de_recebimento_fornecedor_corrige_validacao(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    # testa validação sem arquivos de documentos
+    # testa correção apenas com Laudo (documentos extras são opcionais)
     dados_correcao_sem_documentos = {
         "tipos_de_documentos": [
             {
@@ -2707,7 +2707,7 @@ def test_url_documentos_de_recebimento_fornecedor_corrige_validacao(
         data=json.dumps(dados_correcao_sem_documentos),
     )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_200_OK
 
     # testa validação com payload incompleto
     dados_correcao_sem_arquivos = {

--- a/src/pre_recebimento/documento_recebimento/api/serializers/serializer_create.py
+++ b/src/pre_recebimento/documento_recebimento/api/serializers/serializer_create.py
@@ -263,12 +263,13 @@ class TipoDeDocumentoDeRecebimentoCorrecaoSerializer(serializers.ModelSerializer
 
 class DocumentoDeRecebimentoCorrecaoSerializer(serializers.ModelSerializer):
     tipos_de_documentos = TipoDeDocumentoDeRecebimentoCorrecaoSerializer(
-        many=True, required=True
+        many=True, required=False
     )
 
     def validate(self, attrs):
         tipos_documentos_recebidos = [
-            dados["tipo_documento"] for dados in attrs["tipos_de_documentos"]
+            dados["tipo_documento"]
+            for dados in attrs.get("tipos_de_documentos", [])
         ]
         if (
             TipoDeDocumentoDeRecebimento.TIPO_DOC_LAUDO
@@ -277,20 +278,6 @@ class DocumentoDeRecebimentoCorrecaoSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 {
                     "tipos_de_documentos": "É obrigatório pelo menos um documento do tipo Laudo."
-                }
-            )
-
-        choices_tipos_documentos = set(
-            [choice[0] for choice in TipoDeDocumentoDeRecebimento.TIPO_DOC_CHOICES]
-        )
-        if len(choices_tipos_documentos.intersection(tipos_documentos_recebidos)) < 2:
-            raise serializers.ValidationError(
-                {
-                    "tipos_de_documentos": (
-                        "É obrigatório pelo menos um documento do tipo Laudo"
-                        + " e um documento de algum dos tipos"
-                        + f' {", ".join(choices_tipos_documentos)}.'
-                    )
                 }
             )
 


### PR DESCRIPTION
Este PR:
- corrige validacao errada na correcao de documentos de recebimento que obrigava usuario a inserir outros documentos

[AB#148832](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/148832)