### PR TITLE
Hotfix/149064-adiciona-cargos-ceu-polo-pt2

### DIFF
--- a/src/cardapio/tasks.py
+++ b/src/cardapio/tasks.py
@@ -54,7 +54,9 @@ def ativa_desativa_vinculos_alimentacao_com_periodo_escolar_e_tipo_unidade_escol
     )
 
     # SGP não tem informações de CEU GESTAO, estamos colocando manualmente até o momento 22/07/2022
-    for tipo_unidade in TipoUnidadeEscolar.objects.all().exclude(iniciais="CEU GESTAO"):
+    for tipo_unidade in TipoUnidadeEscolar.objects.all().exclude(
+        iniciais__in=["CEU GESTAO", "CEU POLO", "CEU POLO UAB"]
+    ):
         # atualiza com base nos dados da api do EOL
         for periodo_escolar in PeriodoEscolar.objects.all():
             (


### PR DESCRIPTION
# Este PR:
- da bypass nos tipos de unidade CEU POLO e CEU POLO UAB para a task não inativar os vínculos do tipo de alimentação

### Referência azure:
- [AB#149064](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/149064)