### PR TITLE
Hotfix/149137 e mail fluxo cancelamento parcial inclusao continua

### DIFF
--- a/src/inclusao_alimentacao/__tests__/test_urls.py
+++ b/src/inclusao_alimentacao/__tests__/test_urls.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from freezegun import freeze_time
 from model_bakery import baker
@@ -812,14 +814,21 @@ def test_url_endpoint_inclusao_continua_escola_encerra_periodo_parcial(
             {"uuid": "6f16b41d-151e-4f82-a0d0-43921a9edabe", "cancelado": False},
         ],
     }
-    response = client_autenticado_vinculo_escola_inclusao.patch(
-        f"/inclusoes-alimentacao-continua/{inclusao_alimentacao_continua_codae_autorizado.uuid}/"
-        f"{ESCOLA_CANCELA}/",
-        content_type="application/json",
-        data=data,
-    )
+    with patch(
+        "src.inclusao_alimentacao.api.viewsets.services.enviar_email_ue_cancelar_pedido_parcialmente"
+    ) as mock_enviar_email:
+        response = client_autenticado_vinculo_escola_inclusao.patch(
+            f"/inclusoes-alimentacao-continua/{inclusao_alimentacao_continua_codae_autorizado.uuid}/"
+            f"{ESCOLA_CANCELA}/",
+            content_type="application/json",
+            data=data,
+        )
+
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["status"] == PedidoAPartirDaEscolaWorkflow.CODAE_AUTORIZADO
+    mock_enviar_email.assert_called_once_with(
+        inclusao_alimentacao_continua_codae_autorizado
+    )
 
     qtd_alterada = next(
         q

--- a/src/inclusao_alimentacao/api/viewsets.py
+++ b/src/inclusao_alimentacao/api/viewsets.py
@@ -7,23 +7,18 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from xworkflows import InvalidTransitionError
 
-from ...dados_comuns import constants, services
-from ...dados_comuns.mixins.serializer_context import DataSolicitacaoContextMixin
-from ...dados_comuns.permissions import (
+from src.dados_comuns import constants, services
+from src.dados_comuns.mixins.serializer_context import DataSolicitacaoContextMixin
+from src.dados_comuns.models import LogSolicitacoesUsuario
+from src.dados_comuns.permissions import (
     PermissaoParaRecuperarObjeto,
     UsuarioCODAEGestaoAlimentacao,
     UsuarioDiretoriaRegional,
     UsuarioEmpresaGenerico,
     UsuarioEscolaTercTotal,
 )
-from ...eol_servico.utils import EOLException
-from ...relatorios.relatorios import (
-    relatorio_inclusao_alimentacao_cei,
-    relatorio_inclusao_alimentacao_cemei,
-    relatorio_inclusao_alimentacao_continua,
-    relatorio_inclusao_alimentacao_normal,
-)
-from ..models import (
+from src.eol_servico.utils import EOLException
+from src.inclusao_alimentacao.models import (
     GrupoInclusaoAlimentacaoNormal,
     InclusaoAlimentacaoContinua,
     InclusaoAlimentacaoDaCEI,
@@ -31,6 +26,13 @@ from ..models import (
     MotivoInclusaoContinua,
     MotivoInclusaoNormal,
 )
+from src.relatorios.relatorios import (
+    relatorio_inclusao_alimentacao_cei,
+    relatorio_inclusao_alimentacao_cemei,
+    relatorio_inclusao_alimentacao_continua,
+    relatorio_inclusao_alimentacao_normal,
+)
+
 from .serializers import serializers, serializers_create
 
 
@@ -565,7 +567,6 @@ class InclusaoAlimentacaoContinuaViewSet(
         url_path=constants.ESCOLA_CANCELA,
     )
     def escola_cancela_pedido(self, request, uuid=None):
-        from ...dados_comuns.models import LogSolicitacoesUsuario
 
         obj = self.get_object()
         quantidades_periodo = request.data.get("quantidades_periodo", [])
@@ -590,6 +591,7 @@ class InclusaoAlimentacaoContinuaViewSet(
                     usuario=request.user,
                     justificativa=justificativa,
                 )
+                services.enviar_email_ue_cancelar_pedido_parcialmente(obj)
             else:
                 if len(uuids_selecionados) == obj.quantidades_periodo.count():
                     obj.cancelar_pedido(user=request.user, justificativa=justificativa)


### PR DESCRIPTION
# Este PR:
- adiciona envio de e-mail quando uma inclusão contínua é cancelada parcialmente com a data `encerrado_a_partir_de` preenchida
- implementa teste unitário para o fluxo

### Referência azure:
- [AB#149137](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149137)