### PR TITLE
Feature/148657 integracao kit lanche recreio nas ferias

### DIFF
--- a/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
+++ b/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
@@ -2,6 +2,7 @@ import datetime
 from collections import namedtuple
 
 import pytest
+from django.db.models import Q
 from freezegun.api import freeze_time
 from model_bakery import baker
 from rest_framework import status
@@ -1338,8 +1339,37 @@ def test_kit_lanches_autorizadas_recreio_filtra_periodo_para_todos_tipos(
         def __init__(self, items):
             self.items = list(items)
 
-        def filter(self, **kwargs):
+        def _matches_q(self, item, q_object):
+            resultados = []
+            for filho in q_object.children:
+                if isinstance(filho, Q):
+                    resultados.append(self._matches_q(item, filho))
+                    continue
+
+                lookup, value = filho
+                if lookup == "data_evento__lt":
+                    resultados.append(item.data_evento < value)
+                elif lookup == "data_evento__gt":
+                    resultados.append(item.data_evento > value)
+                elif lookup == "data_evento__lte":
+                    resultados.append(item.data_evento <= value)
+                elif lookup == "data_evento__gte":
+                    resultados.append(item.data_evento >= value)
+                else:
+                    raise AssertionError(f"Lookup não suportado no teste: {lookup}")
+
+            if q_object.connector == "AND":
+                matched = all(resultados)
+            else:
+                matched = any(resultados)
+
+            return not matched if q_object.negated else matched
+
+        def filter(self, *args, **kwargs):
             filtrados = self.items
+            for q_object in args:
+                filtrados = [x for x in filtrados if self._matches_q(x, q_object)]
+
             for lookup, value in kwargs.items():
                 if lookup == "data_evento__month":
                     filtrados = [
@@ -1351,6 +1381,8 @@ def test_kit_lanches_autorizadas_recreio_filtra_periodo_para_todos_tipos(
                     ]
                 elif lookup == "data_evento__lt":
                     filtrados = [x for x in filtrados if x.data_evento < value]
+                elif lookup == "data_evento__gt":
+                    filtrados = [x for x in filtrados if x.data_evento > value]
                 elif lookup == "data_evento__gte":
                     filtrados = [x for x in filtrados if x.data_evento >= value]
                 elif lookup == "data_evento__lte":
@@ -1408,6 +1440,173 @@ def test_kit_lanches_autorizadas_recreio_filtra_periodo_para_todos_tipos(
             },
             {
                 "kit_lanche_id_externo": "uuid-kit-unificado",
+                "tipo_doc": SolicitacoesEscola.TP_SOL_KIT_LANCHE_UNIFICADA,
+            },
+        ]
+    }
+
+
+@freeze_time("2026-03-20")
+def test_kit_lanches_autorizadas_sem_recreio_exclui_periodo_de_recreio_para_todos_tipos(
+    client_autenticado_escola_paineis_consolidados,
+    escola,
+    monkeypatch,
+):
+    client, _ = client_autenticado_escola_paineis_consolidados
+
+    recreio = baker.make(
+        RecreioNasFerias,
+        data_inicio=datetime.date(2026, 3, 3),
+        data_fim=datetime.date(2026, 3, 10),
+    )
+    baker.make(
+        "RecreioNasFeriasUnidadeParticipante",
+        recreio_nas_ferias=recreio,
+        unidade_educacional=escola,
+        lote=escola.lote,
+        liberar_medicao=True,
+    )
+
+    Linha = namedtuple("Linha", ["uuid", "data_evento", "tipo_doc"])
+
+    linhas = [
+        Linha(
+            uuid="uuid-fora-padrao",
+            data_evento=datetime.date(2026, 3, 1),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_AVULSA,
+        ),
+        Linha(
+            uuid="uuid-dentro-padrao",
+            data_evento=datetime.date(2026, 3, 5),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_AVULSA,
+        ),
+        Linha(
+            uuid="uuid-fora-cemei",
+            data_evento=datetime.date(2026, 3, 2),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_CEMEI,
+        ),
+        Linha(
+            uuid="uuid-dentro-cemei",
+            data_evento=datetime.date(2026, 3, 6),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_CEMEI,
+        ),
+        Linha(
+            uuid="uuid-fora-unificado",
+            data_evento=datetime.date(2026, 3, 11),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_UNIFICADA,
+        ),
+        Linha(
+            uuid="uuid-dentro-unificado",
+            data_evento=datetime.date(2026, 3, 8),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_UNIFICADA,
+        ),
+    ]
+
+    class FakeQS:
+        def __init__(self, items):
+            self.items = list(items)
+
+        def _matches_q(self, item, q_object):
+            resultados = []
+            for filho in q_object.children:
+                if isinstance(filho, Q):
+                    resultados.append(self._matches_q(item, filho))
+                    continue
+
+                lookup, value = filho
+                if lookup == "data_evento__lt":
+                    resultados.append(item.data_evento < value)
+                elif lookup == "data_evento__gt":
+                    resultados.append(item.data_evento > value)
+                elif lookup == "data_evento__lte":
+                    resultados.append(item.data_evento <= value)
+                elif lookup == "data_evento__gte":
+                    resultados.append(item.data_evento >= value)
+                else:
+                    raise AssertionError(f"Lookup não suportado no teste: {lookup}")
+
+            if q_object.connector == "AND":
+                matched = all(resultados)
+            else:
+                matched = any(resultados)
+
+            return not matched if q_object.negated else matched
+
+        def filter(self, *args, **kwargs):
+            filtrados = self.items
+            for q_object in args:
+                filtrados = [x for x in filtrados if self._matches_q(x, q_object)]
+
+            for lookup, value in kwargs.items():
+                if lookup == "data_evento__month":
+                    filtrados = [
+                        x for x in filtrados if x.data_evento.month == int(value)
+                    ]
+                elif lookup == "data_evento__year":
+                    filtrados = [
+                        x for x in filtrados if x.data_evento.year == int(value)
+                    ]
+                elif lookup == "data_evento__lt":
+                    filtrados = [x for x in filtrados if x.data_evento < value]
+                elif lookup == "data_evento__gt":
+                    filtrados = [x for x in filtrados if x.data_evento > value]
+                elif lookup == "data_evento__gte":
+                    filtrados = [x for x in filtrados if x.data_evento >= value]
+                elif lookup == "data_evento__lte":
+                    filtrados = [x for x in filtrados if x.data_evento <= value]
+
+            return FakeQS(filtrados)
+
+        def __iter__(self):
+            return iter(self.items)
+
+    fake_qs = FakeQS(linhas)
+
+    monkeypatch.setattr(
+        SolicitacoesEscola,
+        "get_autorizados",
+        classmethod(lambda cls, escola_uuid=None: fake_qs),
+    )
+    monkeypatch.setattr(
+        SolicitacoesEscola,
+        "busca_filtro",
+        classmethod(lambda cls, qs, params: qs),
+    )
+    monkeypatch.setattr(
+        EscolaSolicitacoesViewSet,
+        "remove_duplicados_do_query_set",
+        lambda self, qs: qs,
+    )
+    monkeypatch.setattr(
+        EscolaSolicitacoesViewSet,
+        "_build_results_kit_lanches",
+        lambda self, qs, escola_uuid: [
+            {"kit_lanche_id_externo": item.uuid, "tipo_doc": item.tipo_doc}
+            for item in qs
+        ],
+    )
+
+    params = {
+        "escola_uuid": str(escola.uuid),
+        "mes": "03",
+        "ano": "2026",
+        "tipo_solicitacao": "Kit Lanche",
+    }
+    response = client.get("/escola-solicitacoes/kit-lanches-autorizadas/", params)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "results": [
+            {
+                "kit_lanche_id_externo": "uuid-fora-padrao",
+                "tipo_doc": SolicitacoesEscola.TP_SOL_KIT_LANCHE_AVULSA,
+            },
+            {
+                "kit_lanche_id_externo": "uuid-fora-cemei",
+                "tipo_doc": SolicitacoesEscola.TP_SOL_KIT_LANCHE_CEMEI,
+            },
+            {
+                "kit_lanche_id_externo": "uuid-fora-unificado",
                 "tipo_doc": SolicitacoesEscola.TP_SOL_KIT_LANCHE_UNIFICADA,
             },
         ]

--- a/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
+++ b/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 
 import pytest
 from freezegun.api import freeze_time
+from model_bakery import baker
 from rest_framework import status
 
 from src.cardapio.alteracao_tipo_alimentacao.fixtures.factories.alteracao_tipo_alimentacao_factory import (
@@ -47,7 +48,11 @@ from src.inclusao_alimentacao.fixtures.factories.base_factory import (
     QuantidadePorPeriodoFactory,
 )
 from src.inclusao_alimentacao.models import GrupoInclusaoAlimentacaoNormal
+from src.medicao_inicial.recreio_nas_ferias.models import RecreioNasFerias
 from src.paineis_consolidados.models import SolicitacoesEscola
+from src.paineis_consolidados.solicitacoes_escola.api.viewsets import (
+    EscolaSolicitacoesViewSet,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -1215,3 +1220,195 @@ def test_busca_filtro_tipo_solicitacao_kit_lanche_isolado(monkeypatch, escola):
     }
     assert len(resultado_lista) == 2
     assert {item.tipo_doc for item in resultado_lista} == tipos_validos
+
+
+@freeze_time("2026-03-20")
+def test_kit_lanches_autorizadas_recreio_sem_unidade_participante(
+    client_autenticado_escola_paineis_consolidados,
+    escola,
+):
+    client, _ = client_autenticado_escola_paineis_consolidados
+
+    recreio = baker.make(
+        RecreioNasFerias,
+        data_inicio=datetime.date(2026, 3, 10),
+        data_fim=datetime.date(2026, 3, 15),
+    )
+
+    params = {
+        "escola_uuid": str(escola.uuid),
+        "mes": "03",
+        "ano": "2026",
+        "tipo_solicitacao": "Kit Lanche",
+        "recreio_nas_ferias": str(recreio.uuid),
+    }
+
+    response = client.get("/escola-solicitacoes/kit-lanches-autorizadas/", params)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"results": []}
+
+
+@freeze_time("2026-03-20")
+def test_kit_lanches_autorizadas_recreio_liberar_medicao_false(
+    client_autenticado_escola_paineis_consolidados,
+    escola,
+):
+    client, _ = client_autenticado_escola_paineis_consolidados
+
+    recreio = baker.make(
+        RecreioNasFerias,
+        data_inicio=datetime.date(2026, 3, 10),
+        data_fim=datetime.date(2026, 3, 15),
+    )
+    baker.make(
+        "RecreioNasFeriasUnidadeParticipante",
+        recreio_nas_ferias=recreio,
+        unidade_educacional=escola,
+        lote=escola.lote,
+        liberar_medicao=False,
+    )
+
+    params = {
+        "escola_uuid": str(escola.uuid),
+        "mes": "03",
+        "ano": "2026",
+        "tipo_solicitacao": "Kit Lanche",
+        "recreio_nas_ferias": str(recreio.uuid),
+    }
+
+    response = client.get("/escola-solicitacoes/kit-lanches-autorizadas/", params)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"results": []}
+
+
+@freeze_time("2026-03-20")
+def test_kit_lanches_autorizadas_recreio_filtra_periodo_para_todos_tipos(
+    client_autenticado_escola_paineis_consolidados,
+    escola,
+    monkeypatch,
+):
+    client, _ = client_autenticado_escola_paineis_consolidados
+
+    recreio = baker.make(
+        RecreioNasFerias,
+        data_inicio=datetime.date(2026, 3, 10),
+        data_fim=datetime.date(2026, 3, 15),
+    )
+    baker.make(
+        "RecreioNasFeriasUnidadeParticipante",
+        recreio_nas_ferias=recreio,
+        unidade_educacional=escola,
+        lote=escola.lote,
+        liberar_medicao=True,
+    )
+
+    Linha = namedtuple("Linha", ["uuid", "data_evento", "tipo_doc"])
+
+    linhas = [
+        Linha(
+            uuid="uuid-kit-padrao",
+            data_evento=datetime.date(2026, 3, 12),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_AVULSA,
+        ),
+        Linha(
+            uuid="uuid-kit-cemei",
+            data_evento=datetime.date(2026, 3, 13),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_CEMEI,
+        ),
+        Linha(
+            uuid="uuid-kit-unificado",
+            data_evento=datetime.date(2026, 3, 14),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_UNIFICADA,
+        ),
+        Linha(
+            uuid="uuid-fora-antes",
+            data_evento=datetime.date(2026, 3, 9),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_AVULSA,
+        ),
+        Linha(
+            uuid="uuid-fora-depois",
+            data_evento=datetime.date(2026, 3, 16),
+            tipo_doc=SolicitacoesEscola.TP_SOL_KIT_LANCHE_UNIFICADA,
+        ),
+    ]
+
+    class FakeQS:
+        def __init__(self, items):
+            self.items = list(items)
+
+        def filter(self, **kwargs):
+            filtrados = self.items
+            for lookup, value in kwargs.items():
+                if lookup == "data_evento__month":
+                    filtrados = [
+                        x for x in filtrados if x.data_evento.month == int(value)
+                    ]
+                elif lookup == "data_evento__year":
+                    filtrados = [
+                        x for x in filtrados if x.data_evento.year == int(value)
+                    ]
+                elif lookup == "data_evento__lt":
+                    filtrados = [x for x in filtrados if x.data_evento < value]
+                elif lookup == "data_evento__gte":
+                    filtrados = [x for x in filtrados if x.data_evento >= value]
+                elif lookup == "data_evento__lte":
+                    filtrados = [x for x in filtrados if x.data_evento <= value]
+            return FakeQS(filtrados)
+
+        def __iter__(self):
+            return iter(self.items)
+
+    fake_qs = FakeQS(linhas)
+
+    monkeypatch.setattr(
+        SolicitacoesEscola,
+        "get_autorizados",
+        classmethod(lambda cls, escola_uuid=None: fake_qs),
+    )
+    monkeypatch.setattr(
+        SolicitacoesEscola,
+        "busca_filtro",
+        classmethod(lambda cls, qs, params: qs),
+    )
+    monkeypatch.setattr(
+        EscolaSolicitacoesViewSet,
+        "remove_duplicados_do_query_set",
+        lambda self, qs: qs,
+    )
+    monkeypatch.setattr(
+        EscolaSolicitacoesViewSet,
+        "_build_results_kit_lanches",
+        lambda self, qs, escola_uuid: [
+            {"kit_lanche_id_externo": item.uuid, "tipo_doc": item.tipo_doc}
+            for item in qs
+        ],
+    )
+
+    params = {
+        "escola_uuid": str(escola.uuid),
+        "mes": "03",
+        "ano": "2026",
+        "tipo_solicitacao": "Kit Lanche",
+        "recreio_nas_ferias": str(recreio.uuid),
+    }
+    response = client.get("/escola-solicitacoes/kit-lanches-autorizadas/", params)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "results": [
+            {
+                "kit_lanche_id_externo": "uuid-kit-padrao",
+                "tipo_doc": SolicitacoesEscola.TP_SOL_KIT_LANCHE_AVULSA,
+            },
+            {
+                "kit_lanche_id_externo": "uuid-kit-cemei",
+                "tipo_doc": SolicitacoesEscola.TP_SOL_KIT_LANCHE_CEMEI,
+            },
+            {
+                "kit_lanche_id_externo": "uuid-kit-unificado",
+                "tipo_doc": SolicitacoesEscola.TP_SOL_KIT_LANCHE_UNIFICADA,
+            },
+        ]
+    }

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -916,6 +916,26 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
 
     @action(detail=False, methods=["GET"], url_path=f"{KIT_LANCHES_AUTORIZADAS}")
     def kit_lanches_autorizadas(self, request):
+        """Retorna kits lanches autorizados para a escola no mes e ano informados.
+
+        A consulta considera apenas solicitações autorizadas e eventos anteriores
+        ao dia atual. Quando um UUID de recreio é informado, o retorno fica
+        restrito ao intervalo daquele recreio (desde que a unidade participe e
+        tenha medição liberada). Sem esse parâmetro, os eventos em períodos de
+        recreio com medição liberada são removidos.
+
+        Args:
+            request (Request): Requisição HTTP com os parâmetros de query:
+                escola_uuid (str): UUID da escola.
+                mes (str | int): Mês de referência.
+                ano (str | int): Ano de referência.
+                recreio_nas_ferias (str, optional): UUID do recreio para
+                    filtrar um período específico.
+
+        Returns:
+            Response: Payload no formato
+                {"results": [{"dia", "numero_alunos", "kit_lanche_id_externo"}]}
+        """
         escola_uuid = request.query_params.get("escola_uuid")
         mes = request.query_params.get("mes")
         ano = request.query_params.get("ano")
@@ -952,6 +972,18 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         recreio_uuid,
         escola_uuid,
     ):
+        """Filtra eventos para o intervalo de um recreio especifico.
+
+        Args:
+            query_set (QuerySet): Solicitações consolidadas candidatas.
+            recreio_uuid (str): UUID do Recreio nas férias.
+            escola_uuid (str): UUID da escola usada para validar participação.
+
+        Returns:
+            QuerySet | None: QuerySet filtrado por data quando a unidade e
+            participante com medicao liberada. Retorna None quando o recreio
+            não existe, a escola não participa ou a medicao não esta liberada.
+        """
         unidade = self._get_recreio_nas_ferias_unidade(
             recreio_uuid,
             escola_uuid,
@@ -972,6 +1004,16 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         query_set,
         escola_uuid,
     ):
+        """Remove eventos que acontecem durante periodos de recreio liberados.
+
+        Args:
+            query_set (QuerySet): Solicitações consolidadas candidatas.
+            escola_uuid (str): UUID da escola para obter os períodos de recreio.
+
+        Returns:
+            QuerySet: QuerySet contendo apenas eventos fora de todos os
+            intervalos de recreio com medição liberada para a unidade.
+        """
         periodos_recreio = self._get_periodos_recreio_nas_ferias_unidade(escola_uuid)
 
         filtro_fora_de_todos_os_recreios = Q()
@@ -989,6 +1031,20 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         return query_set
 
     def _build_results_kit_lanches(self, query_set, escola_uuid):
+        """Monta a lista de itens de resposta para kits lanches autorizados.
+
+        Para Kit Lanche CEMEI, usa `total_kits_medicao_inicial`. Para os
+        demais casos, usa `total_kit_lanche_escola` em solicitações unificadas
+        e `quantidade_alimentacoes` nos demais modelos.
+
+        Args:
+            query_set (QuerySet): Solicitações consolidadas já filtradas.
+            escola_uuid (str): UUID da escola usado no cálculo de unificadas.
+
+        Returns:
+            list[dict]: Lista no formato
+                [{"dia", "numero_alunos", "kit_lanche_id_externo"}].
+        """
         results = []
 
         for item in query_set:

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -894,11 +894,10 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         except RecreioNasFerias.DoesNotExist:
             return None
 
-        try:
-            unidade = recreio.unidades_participantes.get(
-                unidade_educacional__uuid=escola_uuid
-            )
-        except RecreioNasFeriasUnidadeParticipante.DoesNotExist:
+        unidade = recreio.unidades_participantes.filter(
+            unidade_educacional__uuid=escola_uuid
+        ).first()
+        if unidade is None:
             return None
 
         if not unidade.liberar_medicao:

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -906,6 +906,15 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
 
         return unidade
 
+    def _get_periodos_recreio_nas_ferias_unidade(self, escola_uuid):
+        return RecreioNasFeriasUnidadeParticipante.objects.filter(
+            unidade_educacional__uuid=escola_uuid,
+            liberar_medicao=True,
+        ).values_list(
+            "recreio_nas_ferias__data_inicio",
+            "recreio_nas_ferias__data_fim",
+        )
+
     @action(detail=False, methods=["GET"], url_path=f"{KIT_LANCHES_AUTORIZADAS}")
     def kit_lanches_autorizadas(self, request):
         escola_uuid = request.query_params.get("escola_uuid")
@@ -927,6 +936,20 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
                 data_evento__gte=recreio.data_inicio,
                 data_evento__lte=recreio.data_fim,
             )
+        else:
+            periodos_recreio = self._get_periodos_recreio_nas_ferias_unidade(
+                escola_uuid
+            )
+            filtro_fora_de_todos_os_recreios = Q()
+            tem_periodo_recreio = False
+            for data_inicio, data_fim in periodos_recreio:
+                tem_periodo_recreio = True
+                filtro_fora_de_todos_os_recreios &= Q(data_evento__lt=data_inicio) | Q(
+                    data_evento__gt=data_fim
+                )
+
+            if tem_periodo_recreio:
+                query_set = query_set.filter(filtro_fora_de_todos_os_recreios)
 
         query_set = self.remove_duplicados_do_query_set(query_set)
 

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -927,33 +927,66 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         query_set = query_set.filter(data_evento__lt=datetime.date.today())
 
         if recreio_uuid:
-            unidade = self._get_recreio_nas_ferias_unidade(recreio_uuid, escola_uuid)
-            if unidade is None:
-                return Response({"results": []})
-            recreio = unidade.recreio_nas_ferias
-            query_set = query_set.filter(
-                data_evento__gte=recreio.data_inicio,
-                data_evento__lte=recreio.data_fim,
+            query_set = self._filtra_por_recreio_especifico(
+                query_set,
+                recreio_uuid,
+                escola_uuid,
             )
-        else:
-            periodos_recreio = self._get_periodos_recreio_nas_ferias_unidade(
-                escola_uuid
-            )
-            filtro_fora_de_todos_os_recreios = Q()
-            tem_periodo_recreio = False
-            for data_inicio, data_fim in periodos_recreio:
-                tem_periodo_recreio = True
-                filtro_fora_de_todos_os_recreios &= Q(data_evento__lt=data_inicio) | Q(
-                    data_evento__gt=data_fim
-                )
 
-            if tem_periodo_recreio:
-                query_set = query_set.filter(filtro_fora_de_todos_os_recreios)
+            if query_set is None:
+                return Response({"results": []})
+        else:
+            query_set = self._remove_eventos_em_periodos_de_recreio(
+                query_set,
+                escola_uuid,
+            )
 
         query_set = self.remove_duplicados_do_query_set(query_set)
 
         results = self._build_results_kit_lanches(query_set, escola_uuid)
         return Response({"results": results})
+
+    def _filtra_por_recreio_especifico(
+        self,
+        query_set,
+        recreio_uuid,
+        escola_uuid,
+    ):
+        unidade = self._get_recreio_nas_ferias_unidade(
+            recreio_uuid,
+            escola_uuid,
+        )
+
+        if unidade is None:
+            return None
+
+        recreio = unidade.recreio_nas_ferias
+
+        return query_set.filter(
+            data_evento__gte=recreio.data_inicio,
+            data_evento__lte=recreio.data_fim,
+        )
+
+    def _remove_eventos_em_periodos_de_recreio(
+        self,
+        query_set,
+        escola_uuid,
+    ):
+        periodos_recreio = self._get_periodos_recreio_nas_ferias_unidade(escola_uuid)
+
+        filtro_fora_de_todos_os_recreios = Q()
+        tem_periodo_recreio = False
+
+        for data_inicio, data_fim in periodos_recreio:
+            tem_periodo_recreio = True
+            filtro_fora_de_todos_os_recreios &= Q(data_evento__lt=data_inicio) | Q(
+                data_evento__gt=data_fim
+            )
+
+        if tem_periodo_recreio:
+            return query_set.filter(filtro_fora_de_todos_os_recreios)
+
+        return query_set
 
     def _build_results_kit_lanches(self, query_set, escola_uuid):
         results = []

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -20,6 +20,10 @@ from src.escola.models import Escola, PeriodoEscolar
 from src.inclusao_alimentacao.models import GrupoInclusaoAlimentacaoNormal
 from src.kit_lanche.models import SolicitacaoKitLancheUnificada
 from src.medicao_inicial.models import SolicitacaoMedicaoInicial
+from src.medicao_inicial.recreio_nas_ferias.models import (
+    RecreioNasFerias,
+    RecreioNasFeriasUnidadeParticipante,
+)
 from src.paineis_consolidados.api.constants import (
     AGUARDANDO_INICIO_VIGENCIA_DIETA_ESPECIAL,
     ALTERACOES_ALIMENTACAO_AUTORIZADAS,
@@ -879,16 +883,51 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
 
         return Response(data)
 
+    def _get_recreio_nas_ferias_unidade(self, recreio_uuid, escola_uuid):
+        """Retorna o RecreioNasFeriasUnidadeParticipante ativo para a escola, ou None.
+
+        Retorna None se o objeto RecreioNasFerias não existir, se a escola não
+        for participante ou se liberar_medicao for False.
+        """
+        try:
+            recreio = RecreioNasFerias.objects.get(uuid=recreio_uuid)
+        except RecreioNasFerias.DoesNotExist:
+            return None
+
+        try:
+            unidade = recreio.unidades_participantes.get(
+                unidade_educacional__uuid=escola_uuid
+            )
+        except RecreioNasFeriasUnidadeParticipante.DoesNotExist:
+            return None
+
+        if not unidade.liberar_medicao:
+            return None
+
+        return unidade
+
     @action(detail=False, methods=["GET"], url_path=f"{KIT_LANCHES_AUTORIZADAS}")
     def kit_lanches_autorizadas(self, request):
         escola_uuid = request.query_params.get("escola_uuid")
         mes = request.query_params.get("mes")
         ano = request.query_params.get("ano")
+        recreio_uuid = request.query_params.get("recreio_nas_ferias")
 
         query_set = SolicitacoesEscola.get_autorizados(escola_uuid=escola_uuid)
         query_set = SolicitacoesEscola.busca_filtro(query_set, request.query_params)
         query_set = query_set.filter(data_evento__month=mes, data_evento__year=ano)
         query_set = query_set.filter(data_evento__lt=datetime.date.today())
+
+        if recreio_uuid:
+            unidade = self._get_recreio_nas_ferias_unidade(recreio_uuid, escola_uuid)
+            if unidade is None:
+                return Response({"results": []})
+            recreio = unidade.recreio_nas_ferias
+            query_set = query_set.filter(
+                data_evento__gte=recreio.data_inicio,
+                data_evento__lte=recreio.data_fim,
+            )
+
         query_set = self.remove_duplicados_do_query_set(query_set)
 
         results = self._build_results_kit_lanches(query_set, escola_uuid)


### PR DESCRIPTION
# Este PR:
- altera o endpoint `kit-lanches-autorizadas` para suportar Recreio nas férias
  - caso exista um recreio nas férias autorizado e com o atributo `liberar_medicao = True` para esta escola, no mês e ano passados como parâmetro:
    - se passar `recreio_nas_ferias` como parâmetro, retorna APENAS os kit lanches autorizados entre `data_inicio` e `data_fim` do recreio
    - se NÃO passar `recreio_nas_ferias` como parâmetro, retornar APENAS os kit lanches autorizados FORA de `data_inicio` e `data_fim` do recreio
- implementa testes unitários para a alteração

### Referência azure:
- [AB#148657](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/148657)