### PR TITLE
Feature/148937 email lembrete fornecedor

### DIFF
--- a/src/dados_comuns/templates/logistica_avisa_sobre_docs_pagamento.html
+++ b/src/dados_comuns/templates/logistica_avisa_sobre_docs_pagamento.html
@@ -1,0 +1,38 @@
+{% extends 'email_base.html' %}
+
+{% block conteudo %}
+<div>
+  Olá!
+</div>
+
+<br/><br/>
+
+<div>
+  Este é um lembrete de que, para a <strong>Etapa {{ etapa }}</strong> do
+  <strong>Cronograma nº {{ numero_cronograma }}</strong>, referente a
+  <strong>{{ nome_produto }}</strong>, é necessário o envio dos Documentos para 
+  Pagamento (Nota Fiscal, Nota Fiscal Eletrônica e Solicitação de Pagamento),
+  a fim de possibilitar o início do Processo de Pagamento.
+</div>
+
+<br/><br/>
+
+<div>
+  Destacamos que o envio correto e completo da documentação é indispensável
+  para a regularidade do processo.
+</div>
+
+<br/><br/>
+
+<div>
+  Ratificamos que o pagamento será realizado em até 30 dias, contados a
+  partir da data de entrega de toda a documentação necessária.
+</div>
+
+<br/><br/>
+
+<div>
+  Caso a documentação já tenha sido previamente encaminhada, ou seu produto não
+  necessite de laudo (FLV), pedimos a gentileza de desconsiderar esta mensagem.
+</div>
+{% endblock %}

--- a/src/dados_comuns/templates/logistica_avisa_sobre_docs_recebimento.html
+++ b/src/dados_comuns/templates/logistica_avisa_sobre_docs_recebimento.html
@@ -1,0 +1,29 @@
+{% extends 'email_base.html' %}
+
+{% block conteudo %}
+<div>
+  Olá!
+</div>
+
+<br/><br/>
+
+<div>
+  Este é um lembrete de que, para a <strong>Etapa {{ etapa }}</strong> do <strong>Cronograma nº {{ numero_cronograma }}</strong>, 
+  referente a <strong>{{ nome_produto }}</strong>, é necessário realizar o cadastro do laudo no SIGPAE com 
+  antecedência mínima de 24 horas em relação à data de entrega.
+</div>
+
+<br/><br/>
+
+<div>
+  Destacamos que o cumprimento desse prazo é indispensável para a regularidade do processo 
+  de entrega e pagamento.
+</div>
+
+<br/><br/>
+
+<div>
+  Caso o laudo correspondente já tenha sido previamente cadastrado, pedimos a gentileza 
+  de desconsiderar esta mensagem.
+</div>
+{% endblock %}

--- a/src/pre_recebimento/__tests__/test_tasks.py
+++ b/src/pre_recebimento/__tests__/test_tasks.py
@@ -16,6 +16,8 @@ from src.pre_recebimento.tasks import (
     _deve_mostrar_linha_a_receber,
     _processar_fichas_recebimento,
     importa_feriados_para_interrupcoes_programadas,
+    avisa_empresa_sobre_etapa_programada_proxima,
+    avisa_empresa_sobre_documentos_pagamento,
 )
 
 
@@ -234,3 +236,108 @@ class TestImportaFeriadosTask:
             motivo=InterrupcaoProgramadaEntrega.MOTIVO_FERIADO
         )
         assert novos_feriados.count() == 3
+
+
+@pytest.mark.django_db
+class TestAvisaEmpresaEtapaProgramadaProxima:
+
+    @freeze_time("2025-01-10")
+    @patch("src.pre_recebimento.tasks.envia_email_em_massa_task")
+    @patch("src.pre_recebimento.tasks.render_to_string", return_value="<html>teste</html>")
+    @patch("src.pre_recebimento.tasks.PartesInteressadasService")
+    def test_envia_email_para_cada_etapa(
+        self, mock_partes_service, mock_render, mock_envia, cronograma_assinado_perfil_dilog
+    ):
+        from model_bakery import baker
+        from src.pre_recebimento.cronograma_entrega.models import EtapasDoCronograma
+
+        data_alvo = date(2025, 1, 13)
+        data_incorreta = date(2025, 1, 14)
+        etapa1 = baker.make(EtapasDoCronograma, cronograma=cronograma_assinado_perfil_dilog, data_programada=data_alvo, etapa=1)
+        etapa2 = baker.make(EtapasDoCronograma, cronograma=cronograma_assinado_perfil_dilog, data_programada=data_alvo, etapa=2)
+
+        mock_partes_service.usuarios_vinculados_a_empresa_do_objeto.return_value = ["empresa@teste.com"]
+
+        avisa_empresa_sobre_etapa_programada_proxima()
+
+        assert mock_envia.delay.call_count == 2
+
+        assuntos = [c.kwargs["assunto"] for c in mock_envia.delay.call_args_list]
+        assert any("Etapa 1" in a for a in assuntos)
+        assert any("Etapa 2" in a for a in assuntos)
+        assert all(cronograma_assinado_perfil_dilog.numero in a for a in assuntos)
+
+    @freeze_time("2025-01-10")
+    @patch("src.pre_recebimento.tasks.envia_email_em_massa_task")
+    @patch("src.pre_recebimento.tasks.render_to_string", return_value="<html>teste</html>")
+    @patch("src.pre_recebimento.tasks.PartesInteressadasService")
+    def test_nao_envia_para_cronogramas_nao_assinados(
+        self, mock_partes_service, mock_render, mock_envia
+    ):
+        from model_bakery import baker
+        from src.pre_recebimento.cronograma_entrega.models import EtapasDoCronograma
+
+        cronograma_rascunho = baker.make("Cronograma", status="RASCUNHO")
+        baker.make(EtapasDoCronograma, cronograma=cronograma_rascunho, data_programada=date(2025, 1, 13), etapa=1)
+
+        avisa_empresa_sobre_etapa_programada_proxima()
+
+        mock_envia.delay.assert_not_called()
+
+    @freeze_time("2025-01-10")
+    @patch("src.pre_recebimento.tasks.envia_email_em_massa_task")
+    @patch("src.pre_recebimento.tasks.render_to_string", return_value="<html>teste</html>")
+    @patch("src.pre_recebimento.tasks.PartesInteressadasService")
+    def test_nao_envia_para_etapas_de_outra_data(
+        self, mock_partes_service, mock_render, mock_envia, cronograma_assinado_perfil_dilog
+    ):
+        from model_bakery import baker
+        from src.pre_recebimento.cronograma_entrega.models import EtapasDoCronograma
+
+        baker.make(EtapasDoCronograma, cronograma=cronograma_assinado_perfil_dilog, data_programada=date(2025, 1, 20), etapa=1)
+
+        avisa_empresa_sobre_etapa_programada_proxima()
+
+        mock_envia.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestAvisaEmpresaDocumentosPagamento:
+
+    @freeze_time("2025-01-10")
+    @patch("src.pre_recebimento.tasks.envia_email_em_massa_task")
+    @patch("src.pre_recebimento.tasks.render_to_string", return_value="<html>teste</html>")
+    @patch("src.pre_recebimento.tasks.PartesInteressadasService")
+    def test_envia_email_para_etapas_do_dia_anterior(
+        self, mock_partes_service, mock_render, mock_envia, cronograma_assinado_perfil_dilog
+    ):
+        from model_bakery import baker
+        from src.pre_recebimento.cronograma_entrega.models import EtapasDoCronograma
+
+        data_alvo = date(2025, 1, 9)
+        baker.make(EtapasDoCronograma, cronograma=cronograma_assinado_perfil_dilog, data_programada=data_alvo, etapa=1)
+
+        mock_partes_service.usuarios_vinculados_a_empresa_do_objeto.return_value = ["empresa@teste.com"]
+
+        avisa_empresa_sobre_documentos_pagamento()
+
+        assert mock_envia.delay.call_count == 1
+        assunto = mock_envia.delay.call_args.kwargs["assunto"]
+        assert "Documentos para Pagamento" in assunto
+        assert cronograma_assinado_perfil_dilog.numero in assunto
+
+    @freeze_time("2025-01-10")
+    @patch("src.pre_recebimento.tasks.envia_email_em_massa_task")
+    @patch("src.pre_recebimento.tasks.render_to_string", return_value="<html>teste</html>")
+    @patch("src.pre_recebimento.tasks.PartesInteressadasService")
+    def test_nao_envia_para_etapas_de_outra_data(
+        self, mock_partes_service, mock_render, mock_envia, cronograma_assinado_perfil_dilog
+    ):
+        from model_bakery import baker
+        from src.pre_recebimento.cronograma_entrega.models import EtapasDoCronograma
+
+        baker.make(EtapasDoCronograma, cronograma=cronograma_assinado_perfil_dilog, data_programada=date(2025, 1, 5), etapa=1)
+
+        avisa_empresa_sobre_documentos_pagamento()
+
+        mock_envia.delay.assert_not_called()

--- a/src/pre_recebimento/tasks.py
+++ b/src/pre_recebimento/tasks.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import logging
 from datetime import date
@@ -8,6 +9,8 @@ from django.template.loader import render_to_string
 from workalendar.america import BrazilSaoPauloCity
 
 from src.dados_comuns.constants import TRADUCOES_FERIADOS
+from src.dados_comuns.services import PartesInteressadasService
+from src.dados_comuns.tasks import envia_email_em_massa_task
 from src.dados_comuns.utils import (
     atualiza_central_download,
     atualiza_central_download_com_erro,
@@ -23,6 +26,7 @@ from src.pre_recebimento.cronograma_entrega.api.serializers.serializers import (
 )
 from src.pre_recebimento.cronograma_entrega.models import (
     Cronograma,
+    EtapasDoCronograma,
     InterrupcaoProgramadaEntrega,
 )
 from src.relatorios.utils import html_to_pdf_file
@@ -574,3 +578,75 @@ def importa_feriados_para_interrupcoes_programadas():
         f"x-x-x-x Finaliza importação de feriados. "
         f"Criados: {feriados_criados}, Ignorados: {feriados_ignorados} x-x-x-x"
     )
+
+
+@shared_task(
+    retry_backoff=2,
+    retry_kwargs={"max_retries": 8},
+)
+def avisa_empresa_sobre_etapa_programada_proxima():
+    data_alvo = datetime.date.today() + datetime.timedelta(days=3)
+
+    etapas = EtapasDoCronograma.objects.filter(
+        data_programada=data_alvo, cronograma__status="ASSINADO_CODAE"
+    ).select_related("cronograma__empresa")
+
+    for etapa in etapas:
+        cronograma = etapa.cronograma
+
+        html = render_to_string(
+            template_name="logistica_avisa_sobre_docs_recebimento.html",
+            context={
+                "titulo": "Lembrete – Cadastro de Laudo",
+                "etapa": etapa.etapa,
+                "numero_cronograma": cronograma.numero,
+                "nome_produto": cronograma.ficha_tecnica.produto,
+            },
+        )
+
+        assunto_str = f"Lembrete – Cadastro de Laudo para a Etapa {etapa.etapa} do Cronograma nº {etapa.cronograma.numero}"
+
+        envia_email_em_massa_task.delay(
+            assunto=assunto_str,
+            emails=PartesInteressadasService.usuarios_vinculados_a_empresa_do_objeto(
+                cronograma, True
+            ),
+            corpo="",
+            html=html,
+        )
+
+
+@shared_task(
+    retry_backoff=2,
+    retry_kwargs={"max_retries": 8},
+)
+def avisa_empresa_sobre_documentos_pagamento():
+    data_alvo = datetime.date.today() + datetime.timedelta(days=-1)
+
+    etapas = EtapasDoCronograma.objects.filter(
+        data_programada=data_alvo, cronograma__status="ASSINADO_CODAE"
+    ).select_related("cronograma__empresa")
+
+    for etapa in etapas:
+        cronograma = etapa.cronograma
+
+        html = render_to_string(
+            template_name="logistica_avisa_sobre_docs_pagamento.html",
+            context={
+                "titulo": "Lembrete – Cadastro de Documentos para Pagamento",
+                "etapa": etapa.etapa,
+                "numero_cronograma": cronograma.numero,
+                "nome_produto": cronograma.ficha_tecnica.produto,
+            },
+        )
+
+        assunto_str = f"Lembrete – Cadastro de Documentos para Pagamento para a Etapa {etapa.etapa} do Cronograma nº {etapa.cronograma.numero}"
+
+        envia_email_em_massa_task.delay(
+            assunto=assunto_str,
+            emails=PartesInteressadasService.usuarios_vinculados_a_empresa_do_objeto(
+                cronograma, True
+            ),
+            corpo="",
+            html=html,
+        )


### PR DESCRIPTION
# Este PR

 - Implementa task periódicas para enviar lembretes (via email) às terceirizadas para lembrar sobre cadastros de documentos;
 - Implementa testes unitários para as tasks.

### Referência Azure

 - [AB#148937](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/148937)