### PR TITLE
Feature/148753 finalizar medicao recreio kit lanche

### DIFF
--- a/src/medicao_inicial/__tests__/test_urls.py
+++ b/src/medicao_inicial/__tests__/test_urls.py
@@ -3061,6 +3061,56 @@ def test_url_endpoint_finaliza_medicao_recreio_emef(
     assert json["logs"][0]["status_evento_explicacao"] == "Enviado pela UE"
 
 
+def test_url_endpoint_finaliza_medicao_recreio_emef_falta_lancamento_kit_lanche(
+    client_autenticado_adm_da_escola,
+    escola,
+    solicitacao_recreio_emef,
+    responsavel,
+    tipo_contagem_alimentacao,
+):
+    from src.dados_comuns.fixtures.factories.dados_comuns_factories import (
+        LogSolicitacoesUsuarioFactory,
+    )
+    from src.dados_comuns.models import LogSolicitacoesUsuario
+    from src.kit_lanche.fixtures.factories.base_factory import (
+        SolicitacaoKitLancheAvulsaFactory,
+    )
+
+    kit_lanche = SolicitacaoKitLancheAvulsaFactory.create(
+        solicitacao_kit_lanche__data="2025-12-20",
+        escola=escola,
+        rastro_escola=escola,
+        rastro_lote=escola.lote,
+        rastro_dre=escola.lote.diretoria_regional,
+        rastro_terceirizada=escola.lote.terceirizada,
+        quantidade_alunos=100,
+        status="CODAE_AUTORIZADO",
+    )
+    LogSolicitacoesUsuarioFactory.create(
+        uuid_original=kit_lanche.uuid,
+        status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        criado_em=datetime.datetime.now(),
+    )
+
+    data_update = {
+        "escola": str(escola.uuid),
+        "tipo_contagem_alimentacoes": str(tipo_contagem_alimentacao.uuid),
+        "com_ocorrencias": False,
+        "finaliza_medicao": True,
+    }
+    response = client_autenticado_adm_da_escola.patch(
+        f"/medicao-inicial/solicitacao-medicao-inicial/{solicitacao_recreio_emef.uuid}/",
+        content_type="application/json",
+        data=data_update,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert {
+        "erro": "Restam dias a serem lançados nos Kit Lanches.",
+        "periodo_escolar": "Solicitações de Alimentação",
+    } in response.json()
+
+
 def test_url_endpoint_finaliza_medicao_recreio_emef_falta_lancamento(
     client_autenticado_adm_da_escola,
     escola,

--- a/src/medicao_inicial/__tests__/test_validators/test_validate_lancamento_kit_lanche.py
+++ b/src/medicao_inicial/__tests__/test_validators/test_validate_lancamento_kit_lanche.py
@@ -1,0 +1,124 @@
+import datetime
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+
+from src.medicao_inicial.validators import validate_lancamento_kit_lanche
+
+pytestmark = pytest.mark.django_db
+
+
+class TestValidateLancamentoKitLanche:
+    @staticmethod
+    def _cria_solicitacao(escola, recreio_nas_ferias=None):
+        solicitacao = baker.make(
+            "SolicitacaoMedicaoInicial",
+            escola=escola,
+            mes="03",
+            ano="2026",
+            recreio_nas_ferias=recreio_nas_ferias,
+        )
+        medicao = baker.make(
+            "Medicao",
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome="Solicitações de Alimentação",
+        )
+        return solicitacao, medicao
+
+    @staticmethod
+    def _cria_valor_kit(medicao, dia):
+        baker.make(
+            "ValorMedicao",
+            medicao=medicao,
+            categoria_medicao=baker.make("CategoriaMedicao", nome="ALIMENTAÇÃO"),
+            nome_campo="kit_lanche",
+            dia=dia,
+            valor="1",
+        )
+
+    def test_quando_medicao_recreio_valida_apenas_dias_dentro_do_recreio(self, escola):
+        recreio = baker.make(
+            "RecreioNasFerias",
+            data_inicio=datetime.date(2026, 3, 15),
+            data_fim=datetime.date(2026, 3, 25),
+        )
+        solicitacao, medicao = self._cria_solicitacao(escola, recreio)
+        self._cria_valor_kit(medicao, "20")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lancamento_kit_lanche(solicitacao, [])
+
+        assert retorno == []
+
+    def test_quando_medicao_recreio_sem_lancamento_no_periodo_retorna_erro(
+        self, escola
+    ):
+        recreio = baker.make(
+            "RecreioNasFerias",
+            data_inicio=datetime.date(2026, 3, 15),
+            data_fim=datetime.date(2026, 3, 25),
+        )
+        solicitacao, medicao = self._cria_solicitacao(escola, recreio)
+        self._cria_valor_kit(medicao, "10")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lancamento_kit_lanche(solicitacao, [])
+
+        assert retorno == [
+            {
+                "periodo_escolar": "Solicitações de Alimentação",
+                "erro": "Restam dias a serem lançados nos Kit Lanches.",
+            }
+        ]
+
+    def test_quando_medicao_nao_recreio_e_escola_liberada_valida_apenas_fora_do_recreio(
+        self, escola
+    ):
+        recreio = baker.make(
+            "RecreioNasFerias",
+            data_inicio=datetime.date(2026, 3, 15),
+            data_fim=datetime.date(2026, 3, 25),
+        )
+        baker.make(
+            "RecreioNasFeriasUnidadeParticipante",
+            recreio_nas_ferias=recreio,
+            unidade_educacional=escola,
+            lote=escola.lote,
+            liberar_medicao=True,
+        )
+        solicitacao, medicao = self._cria_solicitacao(escola)
+        self._cria_valor_kit(medicao, "10")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lancamento_kit_lanche(solicitacao, [])
+
+        assert retorno == []
+
+    def test_quando_medicao_nao_recreio_sem_participacao_valida_todos_os_dias(
+        self, escola
+    ):
+        solicitacao, medicao = self._cria_solicitacao(escola)
+        self._cria_valor_kit(medicao, "10")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lancamento_kit_lanche(solicitacao, [])
+
+        assert retorno == [
+            {
+                "periodo_escolar": "Solicitações de Alimentação",
+                "erro": "Restam dias a serem lançados nos Kit Lanches.",
+            }
+        ]

--- a/src/medicao_inicial/api/serializers_create.py
+++ b/src/medicao_inicial/api/serializers_create.py
@@ -1254,6 +1254,7 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
             instance, lista_erros
         )
         lista_erros = validate_lancamento_dietas_medicao_recreio(instance, lista_erros)
+        lista_erros = validate_lancamento_kit_lanche(instance, lista_erros)
         if lista_erros:
             raise serializers.ValidationError(lista_erros)
 
@@ -1285,6 +1286,7 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         lista_erros = validate_lancamento_dietas_medicao_recreio_cei(
             instance, lista_erros
         )
+        lista_erros = validate_lancamento_kit_lanche(instance, lista_erros)
         if lista_erros:
             raise serializers.ValidationError(lista_erros)
 
@@ -1315,6 +1317,7 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         lista_erros = validate_lancamento_dietas_medicao_recreio_cemei(
             instance, lista_erros
         )
+        lista_erros = validate_lancamento_kit_lanche(instance, lista_erros)
         if lista_erros:
             raise serializers.ValidationError(lista_erros)
 

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -2179,6 +2179,14 @@ def validate_lancamento_dietas_cei_cemei(
 
 
 def remover_duplicados(query_set):
+    """Remove itens duplicados de um queryset com base no UUID.
+
+    Args:
+        query_set (Iterable): Colecao de objetos que possuem o atributo ``uuid``.
+
+    Returns:
+        list: Lista com os objetos sem repeticao de UUID.
+    """
     aux = []
     sem_uuid_repetido = []
     for resultado in query_set:
@@ -2193,14 +2201,47 @@ def _eh_fim_de_semana(data):
 
 
 def _formatar_dia(data):
+    """Formata o dia da data com dois digitos.
+
+    Args:
+        data (datetime.date): Data a ser formatada.
+
+    Returns:
+        str: Dia no formato ``DD``.
+    """
     return str(data.day).rjust(2, "0")
 
 
 def _dia_esta_no_recreio(data_dia, periodos_recreio):
+    """Verifica se uma data pertence a algum intervalo de recreio.
+
+    Args:
+        data_dia (datetime.date): Dia a ser avaliado.
+        periodos_recreio (list[tuple[datetime.date, datetime.date]]):
+            Intervalos ``(inicio, fim)`` do recreio nas ferias.
+
+    Returns:
+        bool: ``True`` quando o dia esta em pelo menos um intervalo.
+    """
     return any(inicio <= data_dia <= fim for inicio, fim in periodos_recreio)
 
 
 def _filtra_dias_kit_lanche_por_recreio(solicitacao, dias_kit_lanche):
+    """Filtra os dias de kit lanche conforme contexto de recreio nas ferias.
+
+    Regras:
+        - Quando a solicitacao e de recreio, considera apenas dias dentro
+          do intervalo do recreio da solicitacao.
+        - Quando nao e recreio, mas a escola participa de recreio no mes com
+          ``liberar_medicao=True``, considera apenas dias fora desses periodos.
+
+    Args:
+        solicitacao (SolicitacaoMedicaoInicial): Solicitacao em validacao.
+        dias_kit_lanche (list[str]): Dias autorizados para kit lanche no formato ``DD``.
+
+    Returns:
+        list[str]: Dias filtrados que devem ser validados no lancamento.
+    """
     if not dias_kit_lanche:
         return dias_kit_lanche
 
@@ -2259,6 +2300,15 @@ def formatar_query_set_alteracao(query_set, mes, ano):
 
 
 def get_lista_dias_solicitacoes(params, escola):
+    """Retorna dias de solicitações autorizadas no mês/ano informado.
+
+    Args:
+        params (dict): Parâmetros de filtro usados em ``SolicitacoesEscola.busca_filtro``.
+        escola (Escola): Escola para busca das solicitações autorizadas.
+
+    Returns:
+        list[str]: Dias no formato ``DD`` para kit lanche ou lanche emergencial.
+    """
     query_set = SolicitacoesEscola.get_autorizados(escola_uuid=escola.uuid)
     query_set = SolicitacoesEscola.busca_filtro(query_set, params)
     query_set = query_set.filter(
@@ -2278,6 +2328,18 @@ def get_lista_dias_solicitacoes(params, escola):
 
 
 def validate_lancamento_kit_lanche(solicitacao, lista_erros):
+    """Valida se os kits lanches autorizados possuem lançamento em ``ValorMedicao``.
+
+    A validação considera regras de recreio nas férias para decidir quais dias
+    devem ser conferidos (dentro ou fora do período de recreio).
+
+    Args:
+        solicitacao (SolicitacaoMedicaoInicial): Solicitação em processo de finalização.
+        lista_erros (list[dict]): Lista acumulada de erros de validação.
+
+    Returns:
+        list[dict]: Lista de erros sem duplicidades.
+    """
     escola = solicitacao.escola
     mes = solicitacao.mes
     ano = solicitacao.ano

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -38,6 +38,7 @@ from .models import (
     SolicitacaoMedicaoInicial,
     ValorMedicao,
 )
+from .recreio_nas_ferias.models import RecreioNasFeriasUnidadeParticipante
 from .utils import (
     agrupa_permissoes_especiais_por_dia,
     get_linhas_da_tabela,
@@ -2195,6 +2196,52 @@ def _formatar_dia(data):
     return str(data.day).rjust(2, "0")
 
 
+def _dia_esta_no_recreio(data_dia, periodos_recreio):
+    return any(inicio <= data_dia <= fim for inicio, fim in periodos_recreio)
+
+
+def _filtra_dias_kit_lanche_por_recreio(solicitacao, dias_kit_lanche):
+    if not dias_kit_lanche:
+        return dias_kit_lanche
+
+    mes = int(solicitacao.mes)
+    ano = int(solicitacao.ano)
+    inicio_mes = datetime.date(ano, mes, 1)
+    fim_mes = datetime.date(ano, mes, calendar.monthrange(ano, mes)[1])
+
+    recreio = getattr(solicitacao, "recreio_nas_ferias", None)
+
+    if recreio:
+        periodos_recreio = [(recreio.data_inicio, recreio.data_fim)]
+    else:
+        participacoes = RecreioNasFeriasUnidadeParticipante.objects.filter(
+            unidade_educacional=solicitacao.escola,
+            liberar_medicao=True,
+            recreio_nas_ferias__data_inicio__lte=fim_mes,
+            recreio_nas_ferias__data_fim__gte=inicio_mes,
+        ).values_list(
+            "recreio_nas_ferias__data_inicio",
+            "recreio_nas_ferias__data_fim",
+        )
+        periodos_recreio = list(set(participacoes))
+
+    if not periodos_recreio:
+        return dias_kit_lanche
+
+    dias_filtrados = []
+
+    for dia in dias_kit_lanche:
+        data_dia = datetime.date(ano, mes, int(dia))
+        dia_no_recreio = _dia_esta_no_recreio(data_dia, periodos_recreio)
+
+        deve_incluir = dia_no_recreio if recreio else not dia_no_recreio
+
+        if deve_incluir:
+            dias_filtrados.append(dia)
+
+    return dias_filtrados
+
+
 def formatar_query_set_alteracao(query_set, mes, ano):
     datas = []
     for alteracao_alimentacao in query_set:
@@ -2243,6 +2290,7 @@ def validate_lancamento_kit_lanche(solicitacao, lista_erros):
     }
     dias_kit_lanche = get_lista_dias_solicitacoes(params, escola)
     dias_kit_lanche = list(set(dias_kit_lanche))
+    dias_kit_lanche = _filtra_dias_kit_lanche_por_recreio(solicitacao, dias_kit_lanche)
 
     valores_da_medicao = (
         ValorMedicao.objects.filter(


### PR DESCRIPTION
# Este PR:
- valida a inserção de kit lanches ao finalizar a medição inicial com recreio nas férias
- atualiza a regra para finalizar medições de escolas que estão no recreio e vão enviar a medição do mês normalmente, para não contar os kit lanches do recreio
- implementa testes unitários para a atualização

### Referência azure:
- [AB#148753](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/148753)