### PR TITLE
Feature/149379 integracao lanche emergencial recreio nas ferias

### DIFF
--- a/src/dados_comuns/constants.py
+++ b/src/dados_comuns/constants.py
@@ -321,6 +321,7 @@ ORDEM_PERIODOS_GRUPOS_RECREIO_NAS_FERIAS = {
     "Recreio nas Férias - de 0 a 3 anos e 11 meses": 2,
     "Recreio nas Férias - 4 a 14 anos": 3,
     "Colaboradores": 4,
+    "Solicitações de Alimentação": 5,
 }
 
 MAX_COLUNAS = 15

--- a/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
+++ b/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
@@ -1035,6 +1035,93 @@ class TestEndpointAlteracoesAutorizadas:
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"results": []}
 
+    def test_alteracoes_autorizadas_lanche_emergencial_sem_recreio_exclui_datas_no_recreio(
+        self,
+        client_autenticado_escola_paineis_consolidados,
+        escola,
+    ):
+        """Sem recreio_nas_ferias na requisição, dias dentro do período de recreio
+        da escola NÃO devem ser retornados; apenas os dias fora do recreio."""
+        client, usuario = client_autenticado_escola_paineis_consolidados
+        self.setup_solicitacoes(
+            escola,
+            usuario,
+            status=GrupoInclusaoAlimentacaoNormal.workflow_class.CODAE_AUTORIZADO,
+            status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        )
+
+        # Recreio cobre os dias 02 e 03 → dia 01 deve ser retornado
+        recreio = baker.make(
+            RecreioNasFerias,
+            data_inicio=datetime.date(2025, 2, 2),
+            data_fim=datetime.date(2025, 2, 3),
+        )
+        baker.make(
+            "RecreioNasFeriasUnidadeParticipante",
+            recreio_nas_ferias=recreio,
+            unidade_educacional=escola,
+            lote=escola.lote,
+            liberar_medicao=True,
+        )
+
+        response = client.get(
+            "/escola-solicitacoes/alteracoes-alimentacao-autorizadas/"
+            f"?escola_uuid={escola.uuid}"
+            f"&tipo_solicitacao=Alteração"
+            f"&mes=02"
+            f"&ano=2025&"
+            f"eh_lanche_emergencial=true"
+            f"&nome_periodo_escolar=MANHA"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == [
+            {
+                "dia": "01",
+                "numero_alunos": 0,
+                "inclusao_id_externo": "C76CF",
+                "motivo": "Lanche Emergencial",
+                "periodos_escolares": ["MANHA"],
+                "tipos_alimentacao_de": ["Refeição", "Lanche"],
+            }
+        ]
+
+    def test_alteracoes_autorizadas_lanche_emergencial_sem_recreio_escola_nao_participante_retorna_todos(
+        self,
+        client_autenticado_escola_paineis_consolidados,
+        escola,
+    ):
+        """Quando há um recreio mas a escola NÃO é participante (ou liberar_medicao=False),
+        todos os dias emergenciais devem ser retornados normalmente."""
+        client, usuario = client_autenticado_escola_paineis_consolidados
+        self.setup_solicitacoes(
+            escola,
+            usuario,
+            status=GrupoInclusaoAlimentacaoNormal.workflow_class.CODAE_AUTORIZADO,
+            status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        )
+
+        # Recreio existe mas a escola não é participante com liberar_medicao=True
+        baker.make(
+            RecreioNasFerias,
+            data_inicio=datetime.date(2025, 2, 2),
+            data_fim=datetime.date(2025, 2, 3),
+        )
+
+        response = client.get(
+            "/escola-solicitacoes/alteracoes-alimentacao-autorizadas/"
+            f"?escola_uuid={escola.uuid}"
+            f"&tipo_solicitacao=Alteração"
+            f"&mes=02"
+            f"&ano=2025&"
+            f"eh_lanche_emergencial=true"
+            f"&nome_periodo_escolar=MANHA"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        dias_retornados = [r["dia"] for r in response.json()["results"]]
+        assert dias_retornados == ["01", "02", "03"]
+
 
 @pytest.mark.usefixtures("client_autenticado_vinculo_escola_cemei", "escola_cemei")
 @freeze_time("2025-02-05")
@@ -1180,6 +1267,57 @@ class TestEndpointAlteracoesAutorizadasCEMEI:
         assert response.json()["results"] == [
             {
                 "dia": "02",
+                "numero_alunos": 0,
+                "inclusao_id_externo": "C76CF",
+                "motivo": "Lanche Emergencial",
+                "periodos_escolares": ["MANHA"],
+                "tipos_alimentacao_de": ["Refeição", "Lanche"],
+            }
+        ]
+
+    def test_alteracoes_autorizadas_lanche_emergencial_cemei_sem_recreio_exclui_datas_no_recreio(
+        self,
+        client_autenticado_vinculo_escola_cemei,
+        escola_cemei,
+    ):
+        """Sem recreio_nas_ferias na requisição, dias dentro do período de recreio
+        da escola CEMEI NÃO devem ser retornados; apenas os dias fora do recreio."""
+        client, usuario = client_autenticado_vinculo_escola_cemei
+        self.setup_solicitacoes(
+            escola_cemei,
+            usuario,
+            status=GrupoInclusaoAlimentacaoNormal.workflow_class.CODAE_AUTORIZADO,
+            status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        )
+
+        # Recreio cobre os dias 02 e 03 → dia 01 deve ser retornado
+        recreio = baker.make(
+            RecreioNasFerias,
+            data_inicio=datetime.date(2025, 2, 2),
+            data_fim=datetime.date(2025, 2, 3),
+        )
+        baker.make(
+            "RecreioNasFeriasUnidadeParticipante",
+            recreio_nas_ferias=recreio,
+            unidade_educacional=escola_cemei,
+            lote=escola_cemei.lote,
+            liberar_medicao=True,
+        )
+
+        response = client.get(
+            "/escola-solicitacoes/alteracoes-alimentacao-autorizadas/"
+            f"?escola_uuid={escola_cemei.uuid}"
+            f"&tipo_solicitacao=Alteração"
+            f"&mes=02"
+            f"&ano=2025&"
+            f"eh_lanche_emergencial=true"
+            f"&nome_periodo_escolar=Infantil+MANHA"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == [
+            {
+                "dia": "01",
                 "numero_alunos": 0,
                 "inclusao_id_externo": "C76CF",
                 "motivo": "Lanche Emergencial",

--- a/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
+++ b/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
@@ -953,6 +953,88 @@ class TestEndpointAlteracoesAutorizadas:
             ]
         }
 
+    def test_alteracoes_autorizadas_lanche_emergencial_recreio_filtra_periodo(
+        self,
+        client_autenticado_escola_paineis_consolidados,
+        escola,
+    ):
+        client, usuario = client_autenticado_escola_paineis_consolidados
+        self.setup_solicitacoes(
+            escola,
+            usuario,
+            status=GrupoInclusaoAlimentacaoNormal.workflow_class.CODAE_AUTORIZADO,
+            status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        )
+
+        recreio = baker.make(
+            RecreioNasFerias,
+            data_inicio=datetime.date(2025, 2, 2),
+            data_fim=datetime.date(2025, 2, 2),
+        )
+        baker.make(
+            "RecreioNasFeriasUnidadeParticipante",
+            recreio_nas_ferias=recreio,
+            unidade_educacional=escola,
+            lote=escola.lote,
+            liberar_medicao=True,
+        )
+
+        response = client.get(
+            "/escola-solicitacoes/alteracoes-alimentacao-autorizadas/"
+            f"?escola_uuid={escola.uuid}"
+            f"&tipo_solicitacao=Alteração"
+            f"&mes=02"
+            f"&ano=2025&"
+            f"eh_lanche_emergencial=true"
+            f"&recreio_nas_ferias={recreio.uuid}"
+            f"&nome_periodo_escolar=MANHA"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == [
+            {
+                "dia": "02",
+                "numero_alunos": 0,
+                "inclusao_id_externo": "C76CF",
+                "motivo": "Lanche Emergencial",
+                "periodos_escolares": ["MANHA"],
+                "tipos_alimentacao_de": ["Refeição", "Lanche"],
+            }
+        ]
+
+    def test_alteracoes_autorizadas_lanche_emergencial_recreio_sem_unidade_participante(
+        self,
+        client_autenticado_escola_paineis_consolidados,
+        escola,
+    ):
+        client, usuario = client_autenticado_escola_paineis_consolidados
+        self.setup_solicitacoes(
+            escola,
+            usuario,
+            status=GrupoInclusaoAlimentacaoNormal.workflow_class.CODAE_AUTORIZADO,
+            status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        )
+
+        recreio = baker.make(
+            RecreioNasFerias,
+            data_inicio=datetime.date(2025, 2, 1),
+            data_fim=datetime.date(2025, 2, 3),
+        )
+
+        response = client.get(
+            "/escola-solicitacoes/alteracoes-alimentacao-autorizadas/"
+            f"?escola_uuid={escola.uuid}"
+            f"&tipo_solicitacao=Alteração"
+            f"&mes=02"
+            f"&ano=2025&"
+            f"eh_lanche_emergencial=true"
+            f"&recreio_nas_ferias={recreio.uuid}"
+            f"&nome_periodo_escolar=MANHA"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"results": []}
+
 
 @pytest.mark.usefixtures("client_autenticado_vinculo_escola_cemei", "escola_cemei")
 @freeze_time("2025-02-05")
@@ -1056,6 +1138,55 @@ class TestEndpointAlteracoesAutorizadasCEMEI:
                 },
             ]
         }
+
+    def test_alteracoes_autorizadas_lanche_emergencial_cemei_recreio_filtra_periodo(
+        self,
+        client_autenticado_vinculo_escola_cemei,
+        escola_cemei,
+    ):
+        client, usuario = client_autenticado_vinculo_escola_cemei
+        self.setup_solicitacoes(
+            escola_cemei,
+            usuario,
+            status=GrupoInclusaoAlimentacaoNormal.workflow_class.CODAE_AUTORIZADO,
+            status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        )
+
+        recreio = baker.make(
+            RecreioNasFerias,
+            data_inicio=datetime.date(2025, 2, 2),
+            data_fim=datetime.date(2025, 2, 2),
+        )
+        baker.make(
+            "RecreioNasFeriasUnidadeParticipante",
+            recreio_nas_ferias=recreio,
+            unidade_educacional=escola_cemei,
+            lote=escola_cemei.lote,
+            liberar_medicao=True,
+        )
+
+        response = client.get(
+            "/escola-solicitacoes/alteracoes-alimentacao-autorizadas/"
+            f"?escola_uuid={escola_cemei.uuid}"
+            f"&tipo_solicitacao=Alteração"
+            f"&mes=02"
+            f"&ano=2025&"
+            f"eh_lanche_emergencial=true"
+            f"&recreio_nas_ferias={recreio.uuid}"
+            f"&nome_periodo_escolar=Infantil+MANHA"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == [
+            {
+                "dia": "02",
+                "numero_alunos": 0,
+                "inclusao_id_externo": "C76CF",
+                "motivo": "Lanche Emergencial",
+                "periodos_escolares": ["MANHA"],
+                "tipos_alimentacao_de": ["Refeição", "Lanche"],
+            }
+        ]
 
 
 @freeze_time("2025-06-30")

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -741,6 +741,7 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         return_dict,
         recreio_data_inicio=None,
         recreio_data_fim=None,
+        periodos_recreio_excluir=None,
     ):
         """Monta o retorno das alteracoes classificadas como lanche emergencial.
 
@@ -775,6 +776,12 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
                 data__gte=recreio_data_inicio,
                 data__lte=recreio_data_fim,
             )
+        elif periodos_recreio_excluir:
+            for data_inicio, data_fim in periodos_recreio_excluir:
+                datas_intervalo = datas_intervalo.exclude(
+                    data__gte=data_inicio,
+                    data__lte=data_fim,
+                )
         for data_evento in datas_intervalo:
             return_dict.append(
                 {
@@ -855,6 +862,7 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         recreio_nas_ferias = request.query_params.get("recreio_nas_ferias")
         recreio_data_inicio = None
         recreio_data_fim = None
+        periodos_recreio_excluir = None
 
         if eh_lanche_emergencial == "true" and recreio_nas_ferias:
             unidade_recreio = self._get_recreio_nas_ferias_unidade(
@@ -867,6 +875,10 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
 
             recreio_data_inicio = unidade_recreio.recreio_nas_ferias.data_inicio
             recreio_data_fim = unidade_recreio.recreio_nas_ferias.data_fim
+        elif eh_lanche_emergencial == "true":
+            periodos_recreio_excluir = list(
+                self._get_periodos_recreio_nas_ferias_unidade(escola_uuid)
+            )
 
         query_set = SolicitacoesEscola.get_autorizados(escola_uuid=escola_uuid)
         query_set = SolicitacoesEscola.busca_filtro(query_set, request.query_params)
@@ -892,6 +904,7 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
                 return_dict,
                 recreio_data_inicio,
                 recreio_data_fim,
+                periodos_recreio_excluir,
             )
             return_dict = self.alteracoes_RPL_LPR(
                 eh_lanche_emergencial,

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -739,6 +739,8 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         mes,
         ano,
         return_dict,
+        recreio_data_inicio=None,
+        recreio_data_fim=None,
     ):
         """Monta o retorno das alteracoes classificadas como lanche emergencial.
 
@@ -768,6 +770,11 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         datas_intervalo = self.filtra_por_periodo_escolar(
             datas_intervalo, alteracao, nome_periodo_escolar
         )
+        if recreio_data_inicio and recreio_data_fim:
+            datas_intervalo = datas_intervalo.filter(
+                data__gte=recreio_data_inicio,
+                data__lte=recreio_data_fim,
+            )
         for data_evento in datas_intervalo:
             return_dict.append(
                 {
@@ -845,6 +852,21 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         ano = request.query_params.get("ano")
         nome_periodo_escolar = request.query_params.get("nome_periodo_escolar")
         eh_lanche_emergencial = request.query_params.get("eh_lanche_emergencial", "")
+        recreio_nas_ferias = request.query_params.get("recreio_nas_ferias")
+        recreio_data_inicio = None
+        recreio_data_fim = None
+
+        if eh_lanche_emergencial == "true" and recreio_nas_ferias:
+            unidade_recreio = self._get_recreio_nas_ferias_unidade(
+                recreio_nas_ferias,
+                escola_uuid,
+            )
+
+            if unidade_recreio is None:
+                return Response({"results": []}, status=status.HTTP_200_OK)
+
+            recreio_data_inicio = unidade_recreio.recreio_nas_ferias.data_inicio
+            recreio_data_fim = unidade_recreio.recreio_nas_ferias.data_fim
 
         query_set = SolicitacoesEscola.get_autorizados(escola_uuid=escola_uuid)
         query_set = SolicitacoesEscola.busca_filtro(query_set, request.query_params)
@@ -868,6 +890,8 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
                 mes,
                 ano,
                 return_dict,
+                recreio_data_inicio,
+                recreio_data_fim,
             )
             return_dict = self.alteracoes_RPL_LPR(
                 eh_lanche_emergencial,


### PR DESCRIPTION
# Este PR:
- implementa a integração do lanche emergencial no lançamento de medição inicial de recreio nas férias
- implementa testes unitários para o novo fluxo

### Referência azure:
- [AB#149379](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149379)