### PR TITLE
Feature/149380 finalizar recreio nas ferias lanche emergencial

### DIFF
--- a/src/medicao_inicial/__tests__/test_validators/test_validate_lanche_emergencial.py
+++ b/src/medicao_inicial/__tests__/test_validators/test_validate_lanche_emergencial.py
@@ -1,0 +1,175 @@
+import datetime
+from unittest.mock import patch
+
+import pytest
+from model_bakery import baker
+
+from src.medicao_inicial.validators import validate_lanche_emergencial
+
+pytestmark = pytest.mark.django_db
+
+
+class TestValidateLancheEmergencial:
+    @staticmethod
+    def _cria_solicitacao(escola, recreio_nas_ferias=None):
+        solicitacao = baker.make(
+            "SolicitacaoMedicaoInicial",
+            escola=escola,
+            mes="03",
+            ano="2026",
+            recreio_nas_ferias=recreio_nas_ferias,
+        )
+        medicao = baker.make(
+            "Medicao",
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome="Solicitações de Alimentação",
+        )
+        return solicitacao, medicao
+
+    @staticmethod
+    def _cria_valor_lanche_emergencial(medicao, dia):
+        baker.make(
+            "ValorMedicao",
+            medicao=medicao,
+            categoria_medicao=baker.make("CategoriaMedicao", nome="ALIMENTAÇÃO"),
+            nome_campo="lanche_emergencial",
+            dia=dia,
+            valor="1",
+        )
+
+    def test_recreio_valida_apenas_dias_dentro_do_recreio(self, escola):
+        recreio = baker.make(
+            "RecreioNasFerias",
+            data_inicio=datetime.date(2026, 3, 15),
+            data_fim=datetime.date(2026, 3, 25),
+        )
+        solicitacao, medicao = self._cria_solicitacao(escola, recreio)
+        self._cria_valor_lanche_emergencial(medicao, "20")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lanche_emergencial(solicitacao, [])
+
+        assert retorno == []
+
+    def test_recreio_sem_lancamento_no_periodo_retorna_erro(self, escola):
+        recreio = baker.make(
+            "RecreioNasFerias",
+            data_inicio=datetime.date(2026, 3, 15),
+            data_fim=datetime.date(2026, 3, 25),
+        )
+        solicitacao, medicao = self._cria_solicitacao(escola, recreio)
+        self._cria_valor_lanche_emergencial(medicao, "10")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lanche_emergencial(solicitacao, [])
+
+        assert retorno == [
+            {
+                "periodo_escolar": "Solicitações de Alimentação",
+                "erro": "Restam dias a serem lançados nos Lanches Emergenciais.",
+            }
+        ]
+
+    def test_nao_recreio_com_escola_liberada_valida_apenas_fora_do_recreio(
+        self, escola
+    ):
+        recreio = baker.make(
+            "RecreioNasFerias",
+            data_inicio=datetime.date(2026, 3, 15),
+            data_fim=datetime.date(2026, 3, 25),
+        )
+        baker.make(
+            "RecreioNasFeriasUnidadeParticipante",
+            recreio_nas_ferias=recreio,
+            unidade_educacional=escola,
+            lote=escola.lote,
+            liberar_medicao=True,
+        )
+        solicitacao, medicao = self._cria_solicitacao(escola)
+        self._cria_valor_lanche_emergencial(medicao, "10")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lanche_emergencial(solicitacao, [])
+
+        assert retorno == []
+
+    def test_nao_recreio_com_escola_liberada_sem_lancamento_fora_retorna_erro(
+        self, escola
+    ):
+        recreio = baker.make(
+            "RecreioNasFerias",
+            data_inicio=datetime.date(2026, 3, 15),
+            data_fim=datetime.date(2026, 3, 25),
+        )
+        baker.make(
+            "RecreioNasFeriasUnidadeParticipante",
+            recreio_nas_ferias=recreio,
+            unidade_educacional=escola,
+            lote=escola.lote,
+            liberar_medicao=True,
+        )
+        solicitacao, medicao = self._cria_solicitacao(escola)
+        self._cria_valor_lanche_emergencial(medicao, "20")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lanche_emergencial(solicitacao, [])
+
+        assert retorno == [
+            {
+                "periodo_escolar": "Solicitações de Alimentação",
+                "erro": "Restam dias a serem lançados nos Lanches Emergenciais.",
+            }
+        ]
+
+    def test_nao_recreio_sem_participacao_valida_todos_os_dias(self, escola):
+        solicitacao, medicao = self._cria_solicitacao(escola)
+        self._cria_valor_lanche_emergencial(medicao, "10")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lanche_emergencial(solicitacao, [])
+
+        assert retorno == [
+            {
+                "periodo_escolar": "Solicitações de Alimentação",
+                "erro": "Restam dias a serem lançados nos Lanches Emergenciais.",
+            }
+        ]
+
+    def test_nao_recreio_sem_participacao_todos_lancados_retorna_sem_erro(self, escola):
+        solicitacao, medicao = self._cria_solicitacao(escola)
+        self._cria_valor_lanche_emergencial(medicao, "10")
+        self._cria_valor_lanche_emergencial(medicao, "20")
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=["10", "20"],
+        ):
+            retorno = validate_lanche_emergencial(solicitacao, [])
+
+        assert retorno == []
+
+    def test_sem_dias_autorizados_retorna_sem_erro(self, escola):
+        solicitacao, medicao = self._cria_solicitacao(escola)
+
+        with patch(
+            "src.medicao_inicial.validators.get_lista_dias_solicitacoes",
+            return_value=[],
+        ):
+            retorno = validate_lanche_emergencial(solicitacao, [])
+
+        assert retorno == []

--- a/src/medicao_inicial/api/serializers_create.py
+++ b/src/medicao_inicial/api/serializers_create.py
@@ -442,9 +442,9 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         quantidade_dias_mes = calendar.monthrange(int(instance.ano), int(instance.mes))[
             1
         ]
-        periodos_escolares = escola.periodos_escolares(ano=instance.ano, mes=instance.mes).values_list(
-            "nome", flat=True
-        )
+        periodos_escolares = escola.periodos_escolares(
+            ano=instance.ano, mes=instance.mes
+        ).values_list("nome", flat=True)
         for dia in range(1, quantidade_dias_mes + 1):
             for periodo_escolar in periodos_escolares:
                 medicao, _ = Medicao.objects.get_or_create(
@@ -513,7 +513,9 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
             1
         ]
         periodos_escolares = list(
-            escola.periodos_escolares(ano=instance.ano, mes=instance.mes).values_list("nome", flat=True)
+            escola.periodos_escolares(ano=instance.ano, mes=instance.mes).values_list(
+                "nome", flat=True
+            )
         )
         if instance.ue_possui_alunos_periodo_parcial:
             periodos_escolares.append("PARCIAL")
@@ -612,9 +614,9 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         quantidade_dias_mes = calendar.monthrange(int(instance.ano), int(instance.mes))[
             1
         ]
-        periodos_escolares = escola.periodos_escolares(ano=instance.ano, mes=instance.mes).values_list(
-            "nome", flat=True
-        )
+        periodos_escolares = escola.periodos_escolares(
+            ano=instance.ano, mes=instance.mes
+        ).values_list("nome", flat=True)
         for dia in range(1, quantidade_dias_mes + 1):
             for categoria in categorias:
                 for periodo_escolar in periodos_escolares:
@@ -751,7 +753,9 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
             1
         ]
         periodos_escolares = list(
-            escola.periodos_escolares(ano=instance.ano, mes=instance.mes).values_list("nome", flat=True)
+            escola.periodos_escolares(ano=instance.ano, mes=instance.mes).values_list(
+                "nome", flat=True
+            )
         )
         if instance.ue_possui_alunos_periodo_parcial:
             periodos_escolares.append("PARCIAL")
@@ -1255,6 +1259,7 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         )
         lista_erros = validate_lancamento_dietas_medicao_recreio(instance, lista_erros)
         lista_erros = validate_lancamento_kit_lanche(instance, lista_erros)
+        lista_erros = validate_lanche_emergencial(instance, lista_erros)
         if lista_erros:
             raise serializers.ValidationError(lista_erros)
 
@@ -1287,6 +1292,7 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
             instance, lista_erros
         )
         lista_erros = validate_lancamento_kit_lanche(instance, lista_erros)
+        lista_erros = validate_lanche_emergencial(instance, lista_erros)
         if lista_erros:
             raise serializers.ValidationError(lista_erros)
 
@@ -1318,6 +1324,7 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
             instance, lista_erros
         )
         lista_erros = validate_lancamento_kit_lanche(instance, lista_erros)
+        lista_erros = validate_lanche_emergencial(instance, lista_erros)
         if lista_erros:
             raise serializers.ValidationError(lista_erros)
 

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -2283,6 +2283,64 @@ def _filtra_dias_kit_lanche_por_recreio(solicitacao, dias_kit_lanche):
     return dias_filtrados
 
 
+def _filtra_dias_lanche_emergencial_por_recreio(solicitacao, dias_lanche_emergencial):
+    """Filtra os dias de lanche emergencial conforme contexto de recreio nas ferias.
+
+    Regras:
+        - Quando a solicitacao e de recreio, considera apenas dias dentro
+          do intervalo do recreio da solicitacao.
+        - Quando nao e recreio, mas a escola participa de recreio no mes com
+          ``liberar_medicao=True``, considera apenas dias fora desses periodos.
+
+    Args:
+        solicitacao (SolicitacaoMedicaoInicial): Solicitacao em validacao.
+        dias_lanche_emergencial (list[str]): Dias autorizados para lanche
+            emergencial no formato ``DD``.
+
+    Returns:
+        list[str]: Dias filtrados que devem ser validados no lancamento.
+    """
+    if not dias_lanche_emergencial:
+        return dias_lanche_emergencial
+
+    mes = int(solicitacao.mes)
+    ano = int(solicitacao.ano)
+    inicio_mes = datetime.date(ano, mes, 1)
+    fim_mes = datetime.date(ano, mes, calendar.monthrange(ano, mes)[1])
+
+    recreio = getattr(solicitacao, "recreio_nas_ferias", None)
+
+    if recreio:
+        periodos_recreio = [(recreio.data_inicio, recreio.data_fim)]
+    else:
+        participacoes = RecreioNasFeriasUnidadeParticipante.objects.filter(
+            unidade_educacional=solicitacao.escola,
+            liberar_medicao=True,
+            recreio_nas_ferias__data_inicio__lte=fim_mes,
+            recreio_nas_ferias__data_fim__gte=inicio_mes,
+        ).values_list(
+            "recreio_nas_ferias__data_inicio",
+            "recreio_nas_ferias__data_fim",
+        )
+        periodos_recreio = list(set(participacoes))
+
+    if not periodos_recreio:
+        return dias_lanche_emergencial
+
+    dias_filtrados = []
+
+    for dia in dias_lanche_emergencial:
+        data_dia = datetime.date(ano, mes, int(dia))
+        dia_no_recreio = _dia_esta_no_recreio(data_dia, periodos_recreio)
+
+        deve_incluir = dia_no_recreio if recreio else not dia_no_recreio
+
+        if deve_incluir:
+            dias_filtrados.append(dia)
+
+    return dias_filtrados
+
+
 def formatar_query_set_alteracao(query_set, mes, ano):
     datas = []
     for alteracao_alimentacao in query_set:
@@ -2377,6 +2435,18 @@ def validate_lancamento_kit_lanche(solicitacao, lista_erros):
 
 
 def validate_lanche_emergencial(solicitacao, lista_erros):
+    """Valida se os lanches emergenciais autorizados possuem lancamento em ``ValorMedicao``.
+
+    A validacao considera regras de recreio nas ferias para decidir quais dias
+    devem ser conferidos (dentro ou fora do periodo de recreio).
+
+    Args:
+        solicitacao (SolicitacaoMedicaoInicial): Solicitacao em processo de finalizacao.
+        lista_erros (list[dict]): Lista acumulada de erros de validacao.
+
+    Returns:
+        list[dict]: Lista de erros sem duplicidades.
+    """
     escola = solicitacao.escola
     mes = solicitacao.mes
     ano = solicitacao.ano
@@ -2392,6 +2462,9 @@ def validate_lanche_emergencial(solicitacao, lista_erros):
     }
     dias_lanche_emergencial = get_lista_dias_solicitacoes(params, escola)
     dias_lanche_emergencial = list(set(dias_lanche_emergencial))
+    dias_lanche_emergencial = _filtra_dias_lanche_emergencial_por_recreio(
+        solicitacao, dias_lanche_emergencial
+    )
 
     valores_da_medicao = (
         ValorMedicao.objects.filter(

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -3517,6 +3517,8 @@ def validate_medicao_cemei(solicitacao):
         dias_motivos_da_inclusao_cemei__cancelado=False,
     ).order_by("dias_motivos_da_inclusao_cemei__data")
     lista_erros = []
+    lista_erros = validate_lancamento_kit_lanche(solicitacao, lista_erros)
+    lista_erros = validate_lanche_emergencial(solicitacao, lista_erros)
     for medicao in solicitacao.medicoes.all():
         tipo_medicao = medicao.nome_periodo_grupo.upper()
         if tipo_medicao in ["INTEGRAL", "PARCIAL"]:
@@ -3536,8 +3538,7 @@ def validate_medicao_cemei(solicitacao):
                 solicitacao, lista_erros, medicao
             )
         elif tipo_medicao == "SOLICITAÇÕES DE ALIMENTAÇÃO":
-            lista_erros = validate_lancamento_kit_lanche(solicitacao, lista_erros)
-            lista_erros = validate_lanche_emergencial(solicitacao, lista_erros)
+            continue
         else:
             lista_erros = _validate_medicao_emei_cemei(
                 lista_erros,


### PR DESCRIPTION
# Este PR:
- implementa a regra ao finalizar medição inicial para recreio nas férias com lanche emergencial
- implementa testes unitários para a nova regra

### Referência azure:
- [AB#149380](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149380)