### PR TITLE
Hotfix/150638 duplicacao logs task geracao

### DIFF
--- a/src/dieta_especial/__tests__/logs_models/test_tasks.py
+++ b/src/dieta_especial/__tests__/logs_models/test_tasks.py
@@ -126,7 +126,7 @@ def setup_dietas_especiais(
 
 
 @freeze_time("2025-02-02")
-def test_gera_logs_dietas_especiais_diariamente_com_logs_gerados(
+def test_gera_logs_dietas_especiais_diariamente_com_logs_gerados_sem_duplicidade(
     escola_cemei,
     escola_emebs,
     escola_cei,
@@ -137,6 +137,12 @@ def test_gera_logs_dietas_especiais_diariamente_com_logs_gerados(
     aluno_factory,
     monkeypatch,
 ):
+    """
+    Garante que, ao executar a task de geração de logs de dietas especiais
+    autorizadas os mesmos sejam criados, e em caso de execução mais de uma
+    vez para a mesma data, não sejam criados registros duplicados
+    de ``LogQuantidadeDietasAutorizadas``.
+    """
     set_up_faixas_etarias(faixa_etaria_factory)
     setup_dietas_especiais(
         escola_cemei,
@@ -159,5 +165,9 @@ def test_gera_logs_dietas_especiais_diariamente_com_logs_gerados(
         },
     )
     assert Aluno.objects.filter(dietas_especiais__isnull=False).count() == 5
+
+    gera_logs_dietas_especiais_diariamente()
+    assert LogQuantidadeDietasAutorizadas.objects.count() == 18
+
     gera_logs_dietas_especiais_diariamente()
     assert LogQuantidadeDietasAutorizadas.objects.count() == 18

--- a/src/dieta_especial/__tests__/logs_models/test_tasks.py
+++ b/src/dieta_especial/__tests__/logs_models/test_tasks.py
@@ -1,17 +1,22 @@
 from collections import Counter
 
 import pytest
+import datetime
+
 from freezegun import freeze_time
 
 from src.dieta_especial.logs_models.models import (
     LogQuantidadeDietasAutorizadas,
     LogQuantidadeDietasAutorizadasCEI,
+    LogQuantidadeDietasAutorizadasRecreioNasFeriasCEI,
+    LogQuantidadeDietasAutorizadasRecreioNasFerias,
 )
 from src.dieta_especial.solicitacao_dieta_especial.models import (
     SolicitacaoDietaEspecial,
 )
 from src.dieta_especial.tasks.logs import (
     gera_logs_dietas_especiais_diariamente,
+    gera_logs_dietas_recreio_ferias_diariamente,
 )
 from src.escola.models import Aluno, Escola
 
@@ -171,3 +176,62 @@ def test_gera_logs_dietas_especiais_diariamente_com_logs_gerados_sem_duplicidade
 
     gera_logs_dietas_especiais_diariamente()
     assert LogQuantidadeDietasAutorizadas.objects.count() == 18
+
+
+@freeze_time("2026-02-02")
+def test_gera_logs_dietas_recreio_ferias_diariamente_sem_duplicidade(
+        escola_cei,
+        periodo_escolar_integral,
+        solicitacao_dieta_especial_factory,
+        faixa_etaria_factory,
+        aluno_factory,
+    ):
+        """
+        Verifica que a geração diária dos logs de Recreio nas Férias não gera duplicidade.
+
+        Ao executar a task mais de uma vez para a mesma data, não devem ser
+        gerados registros duplicados.
+        """
+        set_up_faixas_etarias(faixa_etaria_factory)
+
+        aluno_cei = aluno_factory.create(
+            escola=escola_cei,
+            periodo_escolar=periodo_escolar_integral,
+            data_nascimento="2021-08-02",
+            ciclo=Aluno.CICLO_ALUNO_CEI,
+        )
+
+        solicitacao_dieta_especial_factory.create(
+            rastro_escola=escola_cei,
+            escola_destino=escola_cei,
+            rastro_terceirizada=escola_cei.lote.terceirizada,
+            aluno=aluno_cei,
+            tipo_solicitacao="ALUNO_NAO_MATRICULADO",
+            ativo=True,
+            dieta_para_recreio_ferias=True,
+            status=SolicitacaoDietaEspecial.workflow_class.CODAE_AUTORIZADO,
+            data_inicio=datetime.date(2026, 2, 1),
+            data_termino=datetime.date(2026, 2, 28),
+        )
+
+        gera_logs_dietas_recreio_ferias_diariamente()
+
+        qtd_comuns = (
+            LogQuantidadeDietasAutorizadasRecreioNasFerias.objects.count()
+        )
+
+        qtd_cei = (
+            LogQuantidadeDietasAutorizadasRecreioNasFeriasCEI.objects.count()
+        )
+
+        gera_logs_dietas_recreio_ferias_diariamente()
+
+        assert (
+            LogQuantidadeDietasAutorizadasRecreioNasFerias.objects.count()
+            == qtd_comuns
+        )
+
+        assert (
+            LogQuantidadeDietasAutorizadasRecreioNasFeriasCEI.objects.count()
+            == qtd_cei
+        )

--- a/src/dieta_especial/tasks/logs.py
+++ b/src/dieta_especial/tasks/logs.py
@@ -23,6 +23,8 @@ from src.dieta_especial.tasks.utils.logs import (
     gera_logs_dietas_recreio_ferias_parte_sem_faixa_cemei,
     filtrar_logs_comuns_ja_existentes,
     filtrar_logs_cei_ja_existentes,
+    filtrar_logs_recreio_ferias_ja_existentes,
+    filtrar_logs_recreio_ferias_cei_ja_existentes,
 )
 from src.escola.models import Escola
 from src.escola.utils import datas_para_gerar_logs
@@ -195,9 +197,18 @@ def gera_logs_dietas_recreio_ferias_diariamente():
             )
             logs_a_criar_comuns += logs_comuns
 
+    logs_a_criar_comuns = filtrar_logs_recreio_ferias_ja_existentes(
+        logs_a_criar_comuns
+    )
+
+    logs_a_criar_cei = filtrar_logs_recreio_ferias_cei_ja_existentes(
+        logs_a_criar_cei
+    )
+
     LogQuantidadeDietasAutorizadasRecreioNasFerias.objects.bulk_create(
         logs_a_criar_comuns
     )
+
     LogQuantidadeDietasAutorizadasRecreioNasFeriasCEI.objects.bulk_create(
         logs_a_criar_cei
     )

--- a/src/dieta_especial/tasks/logs.py
+++ b/src/dieta_especial/tasks/logs.py
@@ -21,6 +21,8 @@ from src.dieta_especial.tasks.utils.logs import (
     gera_logs_dietas_recreio_ferias_escolas_cei,
     gera_logs_dietas_recreio_ferias_escolas_comuns,
     gera_logs_dietas_recreio_ferias_parte_sem_faixa_cemei,
+    filtrar_logs_comuns_ja_existentes,
+    filtrar_logs_cei_ja_existentes,
 )
 from src.escola.models import Escola
 from src.escola.utils import datas_para_gerar_logs
@@ -80,8 +82,22 @@ def gera_logs_dietas_especiais_diariamente():
                 logs_a_criar_escolas_comuns += gera_logs_dietas_escolas_comuns(
                     escola, dietas_autorizadas, data_ref
                 )
-    LogQuantidadeDietasAutorizadas.objects.bulk_create(logs_a_criar_escolas_comuns)
-    LogQuantidadeDietasAutorizadasCEI.objects.bulk_create(logs_a_criar_escolas_cei)
+
+    logs_filtrados_comuns = filtrar_logs_comuns_ja_existentes(
+        logs_a_criar_escolas_comuns
+    )
+
+    logs_filtrados_cei = filtrar_logs_cei_ja_existentes(
+        logs_a_criar_escolas_cei
+    )
+
+    LogQuantidadeDietasAutorizadas.objects.bulk_create(
+        logs_filtrados_comuns
+    )
+
+    LogQuantidadeDietasAutorizadasCEI.objects.bulk_create(
+        logs_filtrados_cei
+    )
 
 
 @shared_task(

--- a/src/dieta_especial/tasks/utils/logs.py
+++ b/src/dieta_especial/tasks/utils/logs.py
@@ -664,3 +664,67 @@ def _criar_logs_faixas_sem_alunos(escola, data_log, classificacao, logs_existent
         logs.append(log_zero)
 
     return logs
+
+
+def filtrar_logs_comuns_ja_existentes(logs):
+    chaves_existentes = set(
+        LogQuantidadeDietasAutorizadas.objects.filter(
+            data__in={log.data for log in logs}
+        ).values_list(
+            "escola_id",
+            "data",
+            "classificacao_id",
+            "periodo_escolar_id",
+            "cei_ou_emei",
+            "infantil_ou_fundamental",
+        )
+    )
+
+    logs_filtrados = []
+
+    for log in logs:
+        chave = (
+            log.escola_id,
+            log.data,
+            log.classificacao_id,
+            log.periodo_escolar_id,
+            log.cei_ou_emei,
+            log.infantil_ou_fundamental,
+        )
+
+        if chave not in chaves_existentes:
+            logs_filtrados.append(log)
+            chaves_existentes.add(chave)
+
+    return logs_filtrados
+
+
+def filtrar_logs_cei_ja_existentes(logs):
+    chaves_existentes = set(
+        LogQuantidadeDietasAutorizadasCEI.objects.filter(
+            data__in={log.data for log in logs}
+        ).values_list(
+            "escola_id",
+            "data",
+            "classificacao_id",
+            "periodo_escolar_id",
+            "faixa_etaria_id",
+        )
+    )
+
+    logs_filtrados = []
+
+    for log in logs:
+        chave = (
+            log.escola_id,
+            log.data,
+            log.classificacao_id,
+            log.periodo_escolar_id,
+            log.faixa_etaria_id,
+        )
+
+        if chave not in chaves_existentes:
+            logs_filtrados.append(log)
+            chaves_existentes.add(chave)
+
+    return logs_filtrados

--- a/src/dieta_especial/tasks/utils/logs.py
+++ b/src/dieta_especial/tasks/utils/logs.py
@@ -728,3 +728,59 @@ def filtrar_logs_cei_ja_existentes(logs):
             chaves_existentes.add(chave)
 
     return logs_filtrados
+
+
+def filtrar_logs_recreio_ferias_ja_existentes(logs):
+    chaves_existentes = set(
+        LogQuantidadeDietasAutorizadasRecreioNasFerias.objects.filter(
+            data__in={log.data for log in logs}
+        ).values_list(
+            "escola_id",
+            "data",
+            "classificacao_id",
+        )
+    )
+
+    logs_filtrados = []
+
+    for log in logs:
+        chave = (
+            log.escola_id,
+            log.data,
+            log.classificacao_id,
+        )
+
+        if chave not in chaves_existentes:
+            logs_filtrados.append(log)
+            chaves_existentes.add(chave)
+
+    return logs_filtrados
+
+
+def filtrar_logs_recreio_ferias_cei_ja_existentes(logs):
+    chaves_existentes = set(
+        LogQuantidadeDietasAutorizadasRecreioNasFeriasCEI.objects.filter(
+            data__in={log.data for log in logs}
+        ).values_list(
+            "escola_id",
+            "data",
+            "classificacao_id",
+            "faixa_etaria_id",
+        )
+    )
+
+    logs_filtrados = []
+
+    for log in logs:
+        chave = (
+            log.escola_id,
+            log.data,
+            log.classificacao_id,
+            log.faixa_etaria_id,
+        )
+
+        if chave not in chaves_existentes:
+            logs_filtrados.append(log)
+            chaves_existentes.add(chave)
+
+    return logs_filtrados


### PR DESCRIPTION
**Este pull request**
- Ajusta fluxo das task de geração de logs de dietas para todos os casos (inclusive recreio nas férias).
- Cria testes unitários para garantir funcionamento de filtros para logs duplicados.

Referência no Azure: [AB#150638](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/150638)