### PR TITLE
Feature/149136 dieta especial incluir periodo de matricula do estudante

### DIFF
--- a/src/escola/__tests__/test_models_.py
+++ b/src/escola/__tests__/test_models_.py
@@ -179,6 +179,32 @@ def test_sub_prefeitura(sub_prefeitura):
 def test_aluno(aluno):
     assert aluno.__str__() == "Fulano da Silva - 000001"
 
+def test_aluno_retorna_periodo_escolar(aluno):
+    aluno.nao_matriculado = False
+    aluno.escola.tipo_unidade.iniciais = "EMEF"
+    assert aluno.periodo == aluno.periodo_escolar.nome
+
+def test_aluno_nao_retorna_periodo_quando_nao_tem_codigo_eol(aluno):
+    aluno.codigo_eol = None
+    aluno.nao_matriculado = False
+    aluno.escola.tipo_unidade.iniciais = "EMEF"
+    assert aluno.periodo is None
+
+def test_aluno_nao_retorna_periodo_quando_nao_matriculado(aluno):
+    aluno.nao_matriculado = True
+    aluno.escola.tipo_unidade.iniciais = "EMEF"
+    assert aluno.periodo is None
+
+def test_aluno_nao_retorna_periodo_para_tipo_unidade_cei(aluno):
+    aluno.nao_matriculado = False
+    aluno.escola.tipo_unidade.iniciais = "CEI"
+    assert aluno.periodo is None
+
+def test_aluno_nao_retorna_periodo_para_cei_do_cemei(aluno, escola_cemei):
+    aluno.nao_matriculado = False
+    aluno.escola = escola_cemei
+    aluno.ciclo = aluno.CICLO_ALUNO_CEI
+    assert aluno.periodo is None
 
 @freeze_time("2019-06-20")
 def test_data_pertence_faixa_etaria_hoje(datas_e_faixas):

--- a/src/escola/__tests__/test_serializers.py
+++ b/src/escola/__tests__/test_serializers.py
@@ -1,6 +1,10 @@
+from unittest.mock import patch
+
 import pytest
 
 from src.escola.api.serializers import DiaCalendarioSerializer
+
+from src.escola.api.serializers import AlunoSerializer
 
 pytestmark = pytest.mark.django_db
 
@@ -59,3 +63,19 @@ def test_serialize_dia_calendario_sem_periodo_escolar(dia_calendario_diurno):
     assert data["escola"] == dia_calendario_diurno.escola.nome
     assert data["dia_letivo"] is True
     assert data["periodo_escolar"] is None
+
+
+def test_aluno_serializer_exibe_periodo(aluno):
+    aluno.nao_matriculado = False
+    aluno.escola.tipo_unidade.iniciais = "EMEF"
+
+    with patch.object(
+        AlunoSerializer,
+        "get_possui_dieta_especial",
+        return_value=False,
+    ):
+        serializer = AlunoSerializer(aluno)
+        data = serializer.data
+
+    assert "periodo" in data
+    assert data["periodo"] == aluno.periodo_escolar.nome

--- a/src/escola/api/serializers.py
+++ b/src/escola/api/serializers.py
@@ -750,6 +750,7 @@ class AlunoSerializer(serializers.ModelSerializer):
     nome_dre = serializers.SerializerMethodField()
     responsaveis = ReponsavelSerializer(many=True)
     possui_dieta_especial = serializers.SerializerMethodField()
+    periodo = serializers.CharField(read_only=True)
 
     def get_nome_escola(self, obj):
         return f"{obj.escola.nome}" if obj.escola else None
@@ -813,6 +814,7 @@ class AlunoSerializer(serializers.ModelSerializer):
             "cpf",
             "possui_dieta_especial",
             "serie",
+            "periodo",
         )
 
 

--- a/src/escola/models.py
+++ b/src/escola/models.py
@@ -2745,6 +2745,48 @@ class Aluno(TemChaveExterna):
             return None
         except Exception:
             return None
+    
+    @property
+    def periodo(self):
+        if not self.codigo_eol or self.nao_matriculado:
+            return None
+
+        if not self.escola or not self.escola.tipo_unidade:
+            return None
+
+        tipos_nao_considerados = [
+            "CEI",
+            "CEU CEI",
+            "CCI/CIPS",
+            "CEI DO CEMEI",
+        ]
+
+        tipo_unidade = self.escola.tipo_unidade.iniciais or ""
+
+        if tipo_unidade.upper() in tipos_nao_considerados:
+            return None
+
+        if self.escola.eh_cemei and self.ciclo == self.CICLO_ALUNO_CEI:
+            return None
+
+        if not self.periodo_escolar:
+            return None
+
+        periodo = self.periodo_escolar.nome.upper()
+
+        periodos_permitidos = {
+            "MANHA",
+            "TARDE",
+            "INTEGRAL",
+            "NOITE",
+            "VESPERTINO",
+            "INTERMEDIARIO",
+        }
+
+        if periodo not in periodos_permitidos:
+            return None
+
+        return self.periodo_escolar.nome
 
     def inativar_dieta_especial(self):
         try:

--- a/src/escola/models.py
+++ b/src/escola/models.py
@@ -2756,16 +2756,7 @@ class Aluno(TemChaveExterna):
         ):
             return None
 
-        tipos_nao_considerados = [
-            "CEI",
-            "CEU CEI",
-            "CCI/CIPS",
-            "CEI DO CEMEI",
-        ]
-
-        tipo_unidade = self.escola.tipo_unidade.iniciais or ""
-
-        if tipo_unidade.upper() in tipos_nao_considerados:
+        if self.escola.eh_cei:
             return None
 
         if self.escola.eh_cemei and self.ciclo == self.CICLO_ALUNO_CEI:

--- a/src/escola/models.py
+++ b/src/escola/models.py
@@ -2745,13 +2745,15 @@ class Aluno(TemChaveExterna):
             return None
         except Exception:
             return None
-    
+
     @property
     def periodo(self):
-        if not self.codigo_eol or self.nao_matriculado:
-            return None
-
-        if not self.escola or not self.escola.tipo_unidade:
+        if (
+            not self.codigo_eol
+            or self.nao_matriculado
+            or not self.escola
+            or not self.escola.tipo_unidade
+        ):
             return None
 
         tipos_nao_considerados = [

--- a/src/relatorios/templates/solicitacao_dieta_especial.html
+++ b/src/relatorios/templates/solicitacao_dieta_especial.html
@@ -48,20 +48,12 @@
           </div>
           <div class="col-10">
             <table>
-            {% with periodo=solicitacao.aluno.periodo %}
               <tr>
                 <th scope="col" class="w-25">Cód. EOL do Aluno</th>
-                {% if solicitacao.status == 'CODAE_AUTORIZADO' and solicitacao.ativo and not solicitacao.dieta_alterada and periodo %}
-                  <th scope="col" class="w-25">Período</th>
-                {% endif %}
               </tr>
               <tr>
                 <td>{{ solicitacao.aluno.codigo_eol }}</td>
-                {% if solicitacao.status == 'CODAE_AUTORIZADO' and solicitacao.ativo and not solicitacao.dieta_alterada and periodo %}
-                  <td>{{ periodo|title }}</td>
-                {% endif %}
               </tr>
-            {% endwith %}
               <tr>
                 <th scope="col" class="w-25">Nome completo do Aluno</th>
                 <th scope="col" class="w-25">Data de nascimento</th>

--- a/src/relatorios/templates/solicitacao_dieta_especial.html
+++ b/src/relatorios/templates/solicitacao_dieta_especial.html
@@ -48,12 +48,20 @@
           </div>
           <div class="col-10">
             <table>
+            {% with periodo=solicitacao.aluno.periodo %}
               <tr>
                 <th scope="col" class="w-25">Cód. EOL do Aluno</th>
+                {% if solicitacao.status == 'CODAE_AUTORIZADO' and solicitacao.ativo and not solicitacao.dieta_alterada and periodo %}
+                  <th scope="col" class="w-25">Período</th>
+                {% endif %}
               </tr>
               <tr>
                 <td>{{ solicitacao.aluno.codigo_eol }}</td>
+                {% if solicitacao.status == 'CODAE_AUTORIZADO' and solicitacao.ativo and not solicitacao.dieta_alterada and periodo %}
+                  <td>{{ periodo|title }}</td>
+                {% endif %}
               </tr>
+            {% endwith %}
               <tr>
                 <th scope="col" class="w-25">Nome completo do Aluno</th>
                 <th scope="col" class="w-25">Data de nascimento</th>

--- a/src/relatorios/templates/solicitacao_dieta_especial_protocolo.html
+++ b/src/relatorios/templates/solicitacao_dieta_especial_protocolo.html
@@ -24,35 +24,50 @@
         {% endif %}
         </div>
         <div class="col-9">
-          <table>
+         <table>
+          {% with periodo=solicitacao.aluno.periodo %}
             <tr style="height: 2em">
-              {% if solicitacao.tipo_solicitacao == 'ALUNO_NAO_MATRICULADO'%}
+              {% if solicitacao.tipo_solicitacao == 'ALUNO_NAO_MATRICULADO' %}
                 <th scope="col" class="w-25">CPF do Aluno</th>
-                 {% if solicitacao.dieta_para_recreio_ferias %}
-                    <th scope="col">
-                      <div class="tag-recreio-nas-ferias">Dieta para Recreio nas Férias</div>
-                    </th>
-                 {% endif %}
-              {%else%}
+                {% if solicitacao.dieta_para_recreio_ferias %}
+                  <th scope="col">
+                    <div class="tag-recreio-nas-ferias">
+                      Dieta para Recreio nas Férias
+                    </div>
+                  </th>
+                {% endif %}
+              {% else %}
                 <th scope="col" class="w-25">Cód. EOL do Aluno</th>
-              {%endif%}
+                {% if solicitacao.status == 'CODAE_AUTORIZADO' and solicitacao.ativo and not solicitacao.dieta_alterada and periodo %}
+                  <th scope="col" class="w-25">Período</th>
+                {% endif %}
+              {% endif %}
             </tr>
             <tr style="height: 2em">
-              {% if solicitacao.tipo_solicitacao == 'ALUNO_NAO_MATRICULADO'%}
+              {% if solicitacao.tipo_solicitacao == 'ALUNO_NAO_MATRICULADO' %}
                 <td>{{ solicitacao.aluno.cpf|default:'' }}</td>
-              {%else%}
+              {% else %}
                 <td>{{ solicitacao.aluno.codigo_eol }}</td>
-              {%endif%}
+
+                {% if solicitacao.status == 'CODAE_AUTORIZADO' and solicitacao.ativo and not solicitacao.dieta_alterada and periodo %}
+                  <td>{{ periodo|title }}</td>
+                {% endif %}
+              {% endif %}
             </tr>
-            <tr style="height: 3em">
-              <th scope="col" style="height: 2em" class="w-25">Nome completo do Aluno</th>
-              <th scope="col" class="w-25">Data de nascimento</th>
-            </tr>
-            <tr style="height: 2em">
-                <td>{{ solicitacao.aluno.nome }}</td>
-                <td>{{ solicitacao.aluno.data_nascimento|date:"SHORT_DATE_FORMAT" }}</td>
-            </tr>
-          </table>
+          {% endwith %}
+          <tr style="height: 3em">
+            <th scope="col" style="height: 2em" class="w-25">
+              Nome completo do Aluno
+            </th>
+            <th scope="col" class="w-25">Data de nascimento</th>
+          </tr>
+          <tr style="height: 2em">
+            <td>{{ solicitacao.aluno.nome }}</td>
+            <td>
+              {{ solicitacao.aluno.data_nascimento|date:"SHORT_DATE_FORMAT" }}
+            </td>
+          </tr>
+        </table>
         </div>
       </div>
     {% if solicitacao.tipo_solicitacao == 'ALUNO_NAO_MATRICULADO' %}


### PR DESCRIPTION
### Referência azure:
- [AB#149136](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149136)

## Descrição

Implementa a exibição do período escolar do aluno nas solicitações de Dieta Especial autorizadas.

## Alterações realizadas

* Adicionada a propriedade `periodo` ao model de aluno, centralizando as regras para obtenção do período escolar.
* A lógica foi implementada como `@property` no model porque o período precisa ser utilizado em mais de um contexto, tanto no serializer da API quanto diretamente no template do relatório em PDF. 
* O período é retornado apenas para alunos matriculados, com código EOL e vinculados a unidades escolares permitidas.
* Foram desconsiderados alunos de CEI, CEU CEI, CCI/CIPS e CEI DO CEMEI.
* Adicionada validação para retornar somente os períodos escolares permitidos.
* Incluído o campo `periodo` no serializer de aluno como campo somente leitura.
* Atualizado o relatório em PDF para exibir o período ao lado do código EOL somente em dietas autorizadas, ativas e que não sejam autorizações temporárias.
* Adicionados testes unitários para validar as regras do período no model e sua exposição pelo serializer.