### PR TITLE
Hotfix/152286 medicao cemei evento especifico

### DIFF
--- a/src/cardapio/__tests__/base/test_urls.py
+++ b/src/cardapio/__tests__/base/test_urls.py
@@ -1,10 +1,20 @@
+import datetime
 import json
 
 import pytest
+from model_bakery import baker
 from rest_framework import status
 
 from src.cardapio.base.models import (
     VinculoTipoAlimentacaoComPeriodoEscolarETipoUnidadeEscolar,
+)
+from src.dados_comuns import constants as dados_comuns_constants
+from src.escola.models import PeriodoEscolar
+from src.inclusao_alimentacao.models import (
+    DiasMotivosInclusaoDeAlimentacaoCEMEI,
+    InclusaoDeAlimentacaoCEMEI,
+    MotivoInclusaoNormal,
+    QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI,
 )
 
 pytestmark = pytest.mark.django_db
@@ -255,3 +265,91 @@ def test_url_endpoint_get_vinculos_tipo_alimentacao_escola_mes_diferente(
     json = response.json()["results"]
     # Deve retornar períodos filtrados para dezembro de 2025
     assert len(json) >= 0
+
+
+def test_url_endpoint_vinculos_inclusoes_evento_especifico_cemei(
+    client,
+    django_user_model,
+):
+    terceirizada = baker.make("Terceirizada")
+    lote = baker.make("Lote", terceirizada=terceirizada)
+    tipo_gestao = baker.make("TipoGestao", nome="TERC TOTAL")
+    tipo_unidade_cemei = baker.make("escola.TipoUnidadeEscolar", iniciais="CEMEI")
+    diretoria_regional = baker.make("DiretoriaRegional")
+    escola_cemei = baker.make(
+        "escola.Escola",
+        lote=lote,
+        nome="CEMEI JOAO MENDES",
+        codigo_eol="000546",
+        diretoria_regional=diretoria_regional,
+        tipo_gestao=tipo_gestao,
+        tipo_unidade=tipo_unidade_cemei,
+    )
+
+    email = "test_cemei_evento@test.com"
+    password = dados_comuns_constants.DJANGO_ADMIN_PASSWORD
+    user = django_user_model.objects.create_user(
+        username=email, password=password, email=email, registro_funcional="8888889"
+    )
+    perfil_diretor = baker.make("Perfil", nome="DIRETOR_UE", ativo=True)
+    hoje = datetime.date.today()
+    baker.make(
+        "Vinculo",
+        usuario=user,
+        instituicao=escola_cemei,
+        perfil=perfil_diretor,
+        data_inicial=hoje,
+        ativo=True,
+    )
+    client.login(username=email, password=password)
+
+    motivo = baker.make(MotivoInclusaoNormal, nome="Evento Específico")
+    periodo_manha = baker.make(PeriodoEscolar, nome="MANHA")
+    refeicao = baker.make("cardapio.TipoAlimentacao", nome="Refeicao")
+
+    inclusao = baker.make(
+        InclusaoDeAlimentacaoCEMEI,
+        escola=escola_cemei,
+        rastro_escola=escola_cemei,
+        rastro_lote=lote,
+        rastro_dre=diretoria_regional,
+        status="CODAE_AUTORIZADO",
+    )
+
+    baker.make(
+        DiasMotivosInclusaoDeAlimentacaoCEMEI,
+        inclusao_alimentacao_cemei=inclusao,
+        motivo=motivo,
+        data="2025-02-03",
+    )
+
+    baker.make(
+        QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI,
+        inclusao_alimentacao_cemei=inclusao,
+        periodo_escolar=periodo_manha,
+        quantidade_alunos=20,
+        tipos_alimentacao=[refeicao],
+    )
+
+    tipo_unidade_emei = baker.make("escola.TipoUnidadeEscolar", iniciais="EMEI")
+    baker.make(
+        "cardapio.VinculoTipoAlimentacaoComPeriodoEscolarETipoUnidadeEscolar",
+        tipo_unidade_escolar=tipo_unidade_emei,
+        periodo_escolar=periodo_manha,
+        ativo=True,
+        tipos_alimentacao=[refeicao],
+    )
+
+    response = client.get(
+        f"/{ENDPOINT_VINCULOS_ALIMENTACAO}/vinculos-inclusoes-evento-especifico-autorizadas/"
+        f"?escola_uuid={escola_cemei.uuid}"
+        f"&mes=2"
+        f"&ano=2025"
+        f"&tipo_solicitacao=Inclus%C3%A3o+de"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    results = response.json()
+    assert len(results) > 0
+    periodos_nomes = [r["periodo_escolar"]["nome"] for r in results]
+    assert "MANHA" in periodos_nomes

--- a/src/cardapio/base/api/viewsets.py
+++ b/src/cardapio/base/api/viewsets.py
@@ -40,7 +40,6 @@ from src.inclusao_alimentacao.models import (
     InclusaoAlimentacaoNormal,
     InclusaoDeAlimentacaoCEMEI,
     QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI,
-    QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI,
     QuantidadePorPeriodo,
 )
 
@@ -154,6 +153,11 @@ class VinculoTipoAlimentacaoViewSet(
         os periodos obtidos com os vinculos da escola para montar o conjunto de
         vinculos elegiveis.
 
+        Para escolas CEMEI, tambem consulta inclusoes do tipo
+        ``InclusaoDeAlimentacaoCEMEI`` com motivo ``Evento Especifico``
+        autorizadas no mes, coletando os periodos escolares das quantidades
+        EMEI dessas inclusoes.
+
         Args:
             mes (str | int): Mes de referencia da consulta.
             ano (str | int): Ano de referencia da consulta.
@@ -209,12 +213,6 @@ class VinculoTipoAlimentacaoViewSet(
                 ).values_list("periodo_escolar__uuid", flat=True)
             )
             periodos_escolares_uuids_set.update(cemei_periodos)
-            cemei_cei_periodos = QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI.objects.filter(
-                inclusao_alimentacao_cemei__uuid__in=cemei_uuids
-            ).values_list(
-                "periodo_escolar__uuid", flat=True
-            )
-            periodos_escolares_uuids_set.update(cemei_cei_periodos)
 
         tipo_unidade = "EMEI" if escola.eh_cemei else escola.tipo_unidade.iniciais
 

--- a/src/cardapio/base/api/viewsets.py
+++ b/src/cardapio/base/api/viewsets.py
@@ -38,6 +38,9 @@ from src.escola.constants import PERIODOS_ESPECIAIS_CEMEI
 from src.escola.models import Escola, PeriodoEscolar
 from src.inclusao_alimentacao.models import (
     InclusaoAlimentacaoNormal,
+    InclusaoDeAlimentacaoCEMEI,
+    QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI,
+    QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI,
     QuantidadePorPeriodo,
 )
 
@@ -161,12 +164,15 @@ class VinculoTipoAlimentacaoViewSet(
 
         Returns:
             QuerySet[VinculoTipoAlimentacaoComPeriodoEscolarETipoUnidadeEscolar]:
-            Vinculos compatíveis com o cenario consultado.
+            Vinculos compativeis com o cenario consultado.
         """
+        mes_int = int(mes)
+        ano_int = int(ano)
+
         gupos_uuids = (
             InclusaoAlimentacaoNormal.objects.filter(
-                data__month=int(mes),
-                data__year=int(ano),
+                data__month=mes_int,
+                data__year=ano_int,
                 motivo__nome="Evento Específico",
                 grupo_inclusao__escola=escola,
                 grupo_inclusao__status="CODAE_AUTORIZADO",
@@ -183,14 +189,40 @@ class VinculoTipoAlimentacaoViewSet(
             grupo_inclusao_normal__uuid__in=gupos_uuids
         ).exclude(periodo_escolar__uuid__in=periodos_escolares_uuids)
 
-        periodos_escolares_uuids = quantidades_por_periodo.values_list(
-            "periodo_escolar__uuid"
+        periodos_escolares_uuids_set = set(
+            quantidades_por_periodo.values_list("periodo_escolar__uuid", flat=True)
+        )
+
+        cemei_qs = InclusaoDeAlimentacaoCEMEI.objects.filter(
+            escola=escola,
+            status="CODAE_AUTORIZADO",
+            dias_motivos_da_inclusao_cemei__data__month=mes_int,
+            dias_motivos_da_inclusao_cemei__data__year=ano_int,
+            dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico",
         ).distinct()
+
+        if cemei_qs.exists():
+            cemei_uuids = cemei_qs.values_list("uuid", flat=True)
+            cemei_periodos = (
+                QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI.objects.filter(
+                    inclusao_alimentacao_cemei__uuid__in=cemei_uuids
+                ).values_list("periodo_escolar__uuid", flat=True)
+            )
+            periodos_escolares_uuids_set.update(cemei_periodos)
+            cemei_cei_periodos = QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI.objects.filter(
+                inclusao_alimentacao_cemei__uuid__in=cemei_uuids
+            ).values_list(
+                "periodo_escolar__uuid", flat=True
+            )
+            periodos_escolares_uuids_set.update(cemei_cei_periodos)
+
+        tipo_unidade = "EMEI" if escola.eh_cemei else escola.tipo_unidade.iniciais
+
         vinculos = (
             VinculoTipoAlimentacaoComPeriodoEscolarETipoUnidadeEscolar.objects.filter(
-                tipo_unidade_escolar__iniciais=escola.tipo_unidade.iniciais,
+                tipo_unidade_escolar__iniciais=tipo_unidade,
                 periodo_escolar__nome__in=constants.PERIODOS_INCLUSAO_MOTIVO_ESPECIFICO,
-                periodo_escolar__uuid__in=periodos_escolares_uuids,
+                periodo_escolar__uuid__in=periodos_escolares_uuids_set,
             )
         )
         return vinculos

--- a/src/cardapio/tasks.py
+++ b/src/cardapio/tasks.py
@@ -8,6 +8,7 @@ from src.cardapio.base.models import (
     VinculoTipoAlimentacaoComPeriodoEscolarETipoUnidadeEscolar,
 )
 from src.escola.constants import (
+    PERIODOS_CEMEI_EVENTO_ESPECIFICO,
     PERIODOS_ESPECIAIS_CEI_CEU_CCI,
     PERIODOS_ESPECIAIS_CEI_DIRET,
 )
@@ -83,11 +84,13 @@ def ativa_desativa_vinculos_alimentacao_com_periodo_escolar_e_tipo_unidade_escol
                 vinculo.ativo = tem_alunos_neste_periodo_e_eh_p_fom
                 vinculo.save()
 
-        if tipo_unidade.tem_somente_integral_e_parcial:
-            # deve ter periodo INTEGRAL E PARCIAL somente
-            periodos_escolares = PERIODOS_ESPECIAIS_CEI_CEU_CCI
-            bypass_ativa_vinculos(tipo_unidade, periodos_escolares)
-        if tipo_unidade.eh_cei:
-            # deve ativar INTEGRAL, MANHA E TARDE PARA CEIS DA PROPERTY CRIADA
-            periodos_escolares = PERIODOS_ESPECIAIS_CEI_DIRET
-            bypass_ativa_vinculos(tipo_unidade, periodos_escolares)
+        _bypass_vinculos_por_tipo_unidade(tipo_unidade)
+
+
+def _bypass_vinculos_por_tipo_unidade(tipo_unidade):
+    if tipo_unidade.tem_somente_integral_e_parcial:
+        bypass_ativa_vinculos(tipo_unidade, PERIODOS_ESPECIAIS_CEI_CEU_CCI)
+    if tipo_unidade.eh_cei:
+        bypass_ativa_vinculos(tipo_unidade, PERIODOS_ESPECIAIS_CEI_DIRET)
+    if tipo_unidade.iniciais == "EMEI":
+        bypass_ativa_vinculos(tipo_unidade, PERIODOS_CEMEI_EVENTO_ESPECIFICO)

--- a/src/escola/api/viewsets.py
+++ b/src/escola/api/viewsets.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from calendar import monthrange
+from itertools import chain
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Count, F, Max, Q, Sum
@@ -64,7 +65,10 @@ from ...escola.api.serializers_create import (
     LoteCreateSerializer,
     MudancaFaixasEtariasCreateSerializer,
 )
-from ...inclusao_alimentacao.models import InclusaoAlimentacaoContinua
+from ...inclusao_alimentacao.models import (
+    InclusaoAlimentacaoContinua,
+    InclusaoDeAlimentacaoCEMEI,
+)
 from ...paineis_consolidados.api.constants import FILTRO_DRE_UUID
 from ..forms import AlunosPorFaixaEtariaForm
 from ..models import (
@@ -438,6 +442,23 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
                 )
                 .distinct()
             )
+            cemei_base_qs = InclusaoDeAlimentacaoCEMEI.objects.filter(
+                status="CODAE_AUTORIZADO",
+                rastro_escola=instituicao,
+                dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico",
+                dias_motivos_da_inclusao_cemei__data__gte=primeiro_dia_mes,
+                dias_motivos_da_inclusao_cemei__data__lte=ultimo_dia_mes,
+            )
+            cemei_periodos_cei = cemei_base_qs.values_list(
+                "quantidade_alunos_cei_da_inclusao_cemei__periodo_escolar__nome",
+                "quantidade_alunos_cei_da_inclusao_cemei__periodo_escolar__uuid",
+            )
+            cemei_periodos_emei = cemei_base_qs.values_list(
+                "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__nome",
+                "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__uuid",
+            )
+            cemei_tuples = set(chain(cemei_periodos_cei, cemei_periodos_emei))
+            periodos.update(dict(cemei_tuples))
             return Response({"periodos": periodos if len(periodos) else None})
         except ValidationError as e:
             return Response({"detail": e}, status=status.HTTP_400_BAD_REQUEST)

--- a/src/escola/api/viewsets.py
+++ b/src/escola/api/viewsets.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 from calendar import monthrange
-from itertools import chain
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Count, F, Max, Q, Sum
@@ -403,6 +402,13 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
         ],
     )
     def inclusao_continua_por_mes(self, request):
+        """Retorna periodos escolares de inclusoes continuas e CEMEI Evento Especifico.
+
+        Consulta ``InclusaoAlimentacaoContinua`` autorizadas (exceto ETEC) e
+        ``InclusaoDeAlimentacaoCEMEI`` com motivo ``Evento Especifico``,
+        retornando os periodos escolares distintos (nome e uuid) com datas
+        contidas no mes informado via query params ``mes`` e ``ano``.
+        """
         try:
             for param in ["mes", "ano"]:
                 if param not in request.query_params:
@@ -449,18 +455,12 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
                 dias_motivos_da_inclusao_cemei__data__gte=primeiro_dia_mes,
                 dias_motivos_da_inclusao_cemei__data__lte=ultimo_dia_mes,
             )
-            cemei_periodos_cei = cemei_base_qs.values_list(
-                "quantidade_alunos_cei_da_inclusao_cemei__periodo_escolar__nome",
-                "quantidade_alunos_cei_da_inclusao_cemei__periodo_escolar__uuid",
-            )
             cemei_periodos_emei = cemei_base_qs.values_list(
                 "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__nome",
                 "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__uuid",
             )
             cemei_tuples = {
-                (nome, uuid)
-                for nome, uuid in chain(cemei_periodos_cei, cemei_periodos_emei)
-                if nome is not None
+                (nome, uuid) for nome, uuid in cemei_periodos_emei if nome is not None
             }
             periodos.update(dict(cemei_tuples))
             return Response({"periodos": periodos if len(periodos) else None})

--- a/src/escola/api/viewsets.py
+++ b/src/escola/api/viewsets.py
@@ -444,7 +444,7 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
             )
             cemei_base_qs = InclusaoDeAlimentacaoCEMEI.objects.filter(
                 status="CODAE_AUTORIZADO",
-                rastro_escola=instituicao,
+                escola=instituicao,
                 dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico",
                 dias_motivos_da_inclusao_cemei__data__gte=primeiro_dia_mes,
                 dias_motivos_da_inclusao_cemei__data__lte=ultimo_dia_mes,
@@ -457,7 +457,11 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
                 "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__nome",
                 "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__uuid",
             )
-            cemei_tuples = set(chain(cemei_periodos_cei, cemei_periodos_emei))
+            cemei_tuples = {
+                (nome, uuid)
+                for nome, uuid in chain(cemei_periodos_cei, cemei_periodos_emei)
+                if nome is not None
+            }
             periodos.update(dict(cemei_tuples))
             return Response({"periodos": periodos if len(periodos) else None})
         except ValidationError as e:

--- a/src/medicao_inicial/api/viewsets.py
+++ b/src/medicao_inicial/api/viewsets.py
@@ -67,6 +67,7 @@ from ..models import (
     CategoriaMedicao,
     ClausulaDeDesconto,
     DadosLiquidacao,
+    DescontoFinanceiro,
     DiaParaCorrigir,
     DiaSobremesaDoce,
     Empenho,
@@ -81,7 +82,6 @@ from ..models import (
     SolicitacaoMedicaoInicial,
     TipoContagemAlimentacao,
     ValorMedicao,
-    DescontoFinanceiro,
 )
 from ..tasks import (
     exporta_relatorio_adesao_para_pdf,
@@ -131,8 +131,8 @@ from .serializers import (
     CategoriaMedicaoSerializer,
     ClausulaDeDescontoSerializer,
     DadosLiquidacaoSerializer,
-    DescontoFinanceiroSerializer,
     DadosParametrizacaoFinanceiraSerializer,
+    DescontoFinanceiroSerializer,
     DiaParaCorrigirSerializer,
     DiaSobremesaDoceSerializer,
     EmpenhoSerializer,
@@ -1000,7 +1000,6 @@ class SolicitacaoMedicaoInicialViewSet(
             if not existe_emei and "INTEGRAL" in lista_periodos:
                 lista_periodos.remove("INTEGRAL")
             lista_periodos = sorted(f"Infantil {periodo}" for periodo in lista_periodos)
-
             ordem_personalizada = ordem_periodos(escola, data_referencia).get(
                 "EMEI", {}
             )
@@ -2429,16 +2428,20 @@ class RelatorioFinanceiroViewSet(ModelViewSet):
             mes = int(relatorio_financeiro.mes)
             ano = int(relatorio_financeiro.ano)
 
-            parametrizacao = ParametrizacaoFinanceira.objects.filter(
-                lote=relatorio_financeiro.lote,
-                grupo_unidade_escolar=relatorio_financeiro.grupo_unidade_escolar,
-                data_inicial__lte=datetime.date(
-                    ano, mes, calendar.monthrange(ano, mes)[1]
-                ),
-            ).filter(
-                Q(data_final__gte=datetime.date(ano, mes, 1))
-                | Q(data_final__isnull=True)
-            ).first()
+            parametrizacao = (
+                ParametrizacaoFinanceira.objects.filter(
+                    lote=relatorio_financeiro.lote,
+                    grupo_unidade_escolar=relatorio_financeiro.grupo_unidade_escolar,
+                    data_inicial__lte=datetime.date(
+                        ano, mes, calendar.monthrange(ano, mes)[1]
+                    ),
+                )
+                .filter(
+                    Q(data_final__gte=datetime.date(ano, mes, 1))
+                    | Q(data_final__isnull=True)
+                )
+                .first()
+            )
 
             if not parametrizacao:
                 return Response(
@@ -2617,8 +2620,7 @@ class DadosLiquidacaoViewSet(ModelViewSet):
         )
 
         existentes_por_uuid, existentes_por_chave = mapear_dados_existentes(
-            queryset,
-            chave_composta=["numero_empenho", "tipo_empenho"]
+            queryset, chave_composta=["numero_empenho", "tipo_empenho"]
         )
 
         resultado = []
@@ -2629,7 +2631,7 @@ class DadosLiquidacaoViewSet(ModelViewSet):
                 item_data,
                 existentes_por_uuid,
                 existentes_por_chave,
-                ["numero_empenho", "tipo_empenho"]
+                ["numero_empenho", "tipo_empenho"],
             )
 
             serializer = DadosLiquidacaoUpdateSerializer(

--- a/src/medicao_inicial/services/relatorio_consolidado_cemei.py
+++ b/src/medicao_inicial/services/relatorio_consolidado_cemei.py
@@ -92,7 +92,7 @@ def _get_lista_alimentacoes(
             .order_by("inicio")
         )
     else:
-        lista_alimentacoes = list(
+        lista_alimentacoes = sorted(
             filtra_queryset_pelo_intervalo_de_dias(
                 medicao.valores_medicao, query_params
             )
@@ -136,7 +136,7 @@ def _get_lista_alimentacoes_dietas(
             .order_by("inicio")
         )
     else:
-        return list(
+        return sorted(
             filtra_queryset_pelo_intervalo_de_dias(
                 medicao.valores_medicao, query_params
             )

--- a/src/medicao_inicial/services/relatorio_consolidado_cieja_cmct.py
+++ b/src/medicao_inicial/services/relatorio_consolidado_cieja_cmct.py
@@ -144,7 +144,7 @@ def _get_lista_alimentacoes(
             "total_sobremesas_pagamento",
         ]
 
-    return lista_alimentacoes
+    return sorted(lista_alimentacoes)
 
 
 def _get_lista_alimentacoes_dietas(
@@ -167,7 +167,7 @@ def _get_lista_alimentacoes_dietas(
         >>>  _get_lista_alimentacoes_dietas(medicao, "DIETA ESPECIAL - TIPO B")
         ['lanche', 'lanche_4h', 'refeicao']
     """
-    return list(
+    return sorted(
         filtra_queryset_pelo_intervalo_de_dias(medicao.valores_medicao, query_params)
         .filter(categoria_medicao__nome=categoria)
         .exclude(

--- a/src/medicao_inicial/services/relatorio_consolidado_emebs.py
+++ b/src/medicao_inicial/services/relatorio_consolidado_emebs.py
@@ -89,12 +89,12 @@ def _get_lista_alimentacoes(medicao, nome_periodo, query_params=None):
         | Q(categoria_medicao__nome__icontains="DIETA ESPECIAL")
     )
 
-    infantil = list(
+    infantil = sorted(
         lista_alimentacoes.filter(infantil_ou_fundamental="INFANTIL")
         .values_list("nome_campo", flat=True)
         .distinct()
     )
-    fundamental = list(
+    fundamental = sorted(
         lista_alimentacoes.filter(infantil_ou_fundamental="FUNDAMENTAL")
         .values_list("nome_campo", flat=True)
         .distinct()
@@ -168,7 +168,7 @@ def _obter_dietas_especiais(
 
 
 def _get_lista_alimentacoes_dietas(medicao, categoria, turma, query_params=None):
-    return list(
+    return sorted(
         filtra_queryset_pelo_intervalo_de_dias(medicao.valores_medicao, query_params)
         .filter(categoria_medicao__nome=categoria, infantil_ou_fundamental=turma)
         .exclude(

--- a/src/medicao_inicial/services/relatorio_consolidado_emei_emef.py
+++ b/src/medicao_inicial/services/relatorio_consolidado_emei_emef.py
@@ -65,7 +65,7 @@ def get_alimentacoes_por_periodo(solicitacoes, query_params=None):
 
 
 def _get_lista_alimentacoes(medicao, nome_periodo, query_params=None):
-    lista_alimentacoes = list(
+    lista_alimentacoes = sorted(
         filtra_queryset_pelo_intervalo_de_dias(medicao.valores_medicao, query_params)
         .exclude(
             Q(
@@ -93,7 +93,7 @@ def _get_lista_alimentacoes(medicao, nome_periodo, query_params=None):
 
 
 def _get_lista_alimentacoes_dietas(medicao, categoria, query_params=None):
-    return list(
+    return sorted(
         filtra_queryset_pelo_intervalo_de_dias(medicao.valores_medicao, query_params)
         .filter(categoria_medicao__nome=categoria)
         .exclude(

--- a/src/medicao_inicial/services/relatorio_consolidado_recreio_emei_emef.py
+++ b/src/medicao_inicial/services/relatorio_consolidado_recreio_emei_emef.py
@@ -152,7 +152,7 @@ def _get_lista_alimentacoes(
             "total_sobremesas_pagamento"
         ]
     """
-    lista_alimentacoes = list(
+    lista_alimentacoes = sorted(
         filtra_queryset_pelo_intervalo_de_dias(medicao.valores_medicao, query_params)
         .exclude(
             Q(
@@ -214,7 +214,7 @@ def _get_lista_alimentacoes_dietas(
         ... )
         ["lanche", "refeicao"]
     """
-    return list(
+    return sorted(
         filtra_queryset_pelo_intervalo_de_dias(medicao.valores_medicao, query_params)
         .filter(categoria_medicao__nome=categoria)
         .exclude(

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -3144,15 +3144,18 @@ def _validate_solicitacoes_programas_e_projetos_emei_cemei(
 ):
     inclusoes = get_inclusoes_programas_projetos(solicitacao)
 
-    if not inclusoes:
-        return lista_erros
-    lista_erros = validate_solicitacoes_continuas_emei_cemei(
-        solicitacao,
-        lista_erros,
-        inclusoes,
-        medicao,
-        "Programas e Projetos",
-        True,
+    if inclusoes:
+        lista_erros = validate_solicitacoes_continuas_emei_cemei(
+            solicitacao,
+            lista_erros,
+            inclusoes,
+            medicao,
+            "Programas e Projetos",
+            True,
+        )
+
+    lista_erros = validate_cemei_evento_especifico_programas(
+        solicitacao, medicao, lista_erros
     )
 
     lista_erros = valida_programas_e_projetos_periodos_zero(
@@ -3160,6 +3163,90 @@ def _validate_solicitacoes_programas_e_projetos_emei_cemei(
     )
 
     return erros_unicos(lista_erros)
+
+
+def validate_cemei_evento_especifico_programas(solicitacao, medicao, lista_erros):
+    mes = int(solicitacao.mes)
+    ano = int(solicitacao.ano)
+    primeiro_dia_mes = datetime.date(ano, mes, 1)
+    ultimo_dia_mes = get_ultimo_dia_mes(primeiro_dia_mes)
+
+    cemei_evento_qs = InclusaoDeAlimentacaoCEMEI.objects.filter(
+        escola=solicitacao.escola,
+        status="CODAE_AUTORIZADO",
+        dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico",
+        dias_motivos_da_inclusao_cemei__data__gte=primeiro_dia_mes,
+        dias_motivos_da_inclusao_cemei__data__lte=ultimo_dia_mes,
+        dias_motivos_da_inclusao_cemei__cancelado=False,
+        quantidade_alunos_emei_da_inclusao_cemei__isnull=False,
+    ).distinct()
+
+    if not cemei_evento_qs.exists():
+        return lista_erros
+
+    categoria = CategoriaMedicao.objects.get(nome="ALIMENTAÇÃO")
+    periodo_com_erro = any(
+        _valida_uma_inclusao_cemei_evento_especifico(
+            inc, primeiro_dia_mes, ultimo_dia_mes, medicao, categoria
+        )
+        for inc in cemei_evento_qs
+    )
+
+    if periodo_com_erro:
+        lista_erros.append(
+            {
+                "periodo_escolar": "Programas e Projetos",
+                "erro": "Restam dias a serem lançados nas alimentações.",
+            }
+        )
+
+    return erros_unicos(lista_erros)
+
+
+def _valida_uma_inclusao_cemei_evento_especifico(
+    inc, primeiro_dia_mes, ultimo_dia_mes, medicao, categoria
+):
+    dias_evento = inc.dias_motivos_da_inclusao_cemei.filter(
+        motivo__nome="Evento Específico",
+        cancelado=False,
+        data__gte=primeiro_dia_mes,
+        data__lte=ultimo_dia_mes,
+    ).values_list("data", flat=True)
+
+    tipos_alimentacao = set()
+    for qe in inc.quantidade_alunos_emei_da_inclusao_cemei.all():
+        tipos_alimentacao.update(
+            qe.tipos_alimentacao.all().values_list("nome", flat=True)
+        )
+    tipos_alimentacao = list(tipos_alimentacao)
+    if not tipos_alimentacao:
+        return False
+
+    nomes_campos = _build_nomes_campos_cemei_evento(tipos_alimentacao)
+
+    for data_evento in dias_evento:
+        dia_str = f"{data_evento.day:02d}"
+        for nome_campo in nomes_campos:
+            if not medicao.valores_medicao.filter(
+                categoria_medicao=categoria,
+                nome_campo=nome_campo,
+                dia=dia_str,
+            ).exists():
+                return True
+
+    return False
+
+
+def _build_nomes_campos_cemei_evento(tipos_alimentacao):
+    nomes_campos = ["frequencia"]
+    nomes_campos = append_lanches_nomes_campos(nomes_campos, tipos_alimentacao)
+    if "Refeição" in tipos_alimentacao:
+        nomes_campos.append("refeicao")
+        nomes_campos.append("repeticao_refeicao")
+    if "Sobremesa" in tipos_alimentacao:
+        nomes_campos.append("sobremesa")
+        nomes_campos.append("repeticao_sobremesa")
+    return nomes_campos
 
 
 def validate_solicitacoes_etec(solicitacao, lista_erros):

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -3618,7 +3618,11 @@ def validate_medicao_cemei(solicitacao):
                 dias_letivos_uteis,
                 categoria_alimentacao,
                 dias_nao_letivos,
-                inclusoes.filter(quantidade_alunos_cei_da_inclusao_cemei__isnull=False),
+                inclusoes.filter(
+                    quantidade_alunos_cei_da_inclusao_cemei__isnull=False
+                ).exclude(
+                    dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico"
+                ),
             )
         elif tipo_medicao == "PROGRAMAS E PROJETOS":
             lista_erros = _validate_solicitacoes_programas_e_projetos_emei_cemei(
@@ -3635,6 +3639,8 @@ def validate_medicao_cemei(solicitacao):
                 dias_letivos_uteis,
                 inclusoes.filter(
                     quantidade_alunos_emei_da_inclusao_cemei__isnull=False
+                ).exclude(
+                    dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico"
                 ),
                 medicao,
                 mes,

--- a/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
+++ b/src/paineis_consolidados/__tests__/solicitacoes_escola/test_solicitacoes_escola_viewset.py
@@ -44,11 +44,15 @@ from src.inclusao_alimentacao.fixtures.factories.base_factory import (
     InclusaoAlimentacaoNormalFactory,
     InclusaoDeAlimentacaoCEMEIFactory,
     MotivoInclusaoContinuaFactory,
+    MotivoInclusaoNormalFactory,
     QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEIFactory,
     QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEIFactory,
     QuantidadePorPeriodoFactory,
 )
-from src.inclusao_alimentacao.models import GrupoInclusaoAlimentacaoNormal
+from src.inclusao_alimentacao.models import (
+    GrupoInclusaoAlimentacaoNormal,
+    InclusaoDeAlimentacaoCEMEI,
+)
 from src.medicao_inicial.recreio_nas_ferias.models import RecreioNasFerias
 from src.paineis_consolidados.models import SolicitacoesEscola
 from src.paineis_consolidados.solicitacoes_escola.api.viewsets import (
@@ -714,6 +718,61 @@ class TestEndpointInclusoesAutorizadas:
                 "faixas_etarias": [str(self.faixa_etaria.uuid)],
             }
         ]
+
+    def test_inclusoes_autorizadas_cemei_evento_especifico_respeita_excluir_continuas(
+        self,
+        client_autenticado_vinculo_escola_cemei,
+        escola_cemei,
+    ):
+        client, usuario = client_autenticado_vinculo_escola_cemei
+        motivo_evento_especifico = MotivoInclusaoNormalFactory.create(
+            nome="Evento Específico"
+        )
+        self.setup_solicitacoes(
+            escola_cemei,
+            usuario,
+            status=GrupoInclusaoAlimentacaoNormal.workflow_class.CODAE_AUTORIZADO,
+            status_evento=LogSolicitacoesUsuario.CODAE_AUTORIZOU,
+        )
+        inclusao_cemei = InclusaoDeAlimentacaoCEMEI.objects.first()
+        dias_motivo = inclusao_cemei.dias_motivos_da_inclusao_cemei.first()
+        dias_motivo.motivo = motivo_evento_especifico
+        dias_motivo.save()
+
+        response_com = client.get(
+            "/escola-solicitacoes/inclusoes-autorizadas/"
+            f"?escola_uuid={escola_cemei.uuid}"
+            f"&tipo_solicitacao=Inclus%C3%A3o+de"
+            f"&mes=2"
+            f"&ano=2025"
+            f"&periodos_escolares[]=MANHA"
+            f"&excluir_inclusoes_continuas=true"
+            f"&cemei_emei=true"
+        )
+        assert response_com.status_code == status.HTTP_200_OK
+        assert response_com.json()["results"] == []
+
+        response_sem = client.get(
+            "/escola-solicitacoes/inclusoes-autorizadas/"
+            f"?escola_uuid={escola_cemei.uuid}"
+            f"&tipo_solicitacao=Inclus%C3%A3o+de"
+            f"&mes=2"
+            f"&ano=2025"
+            f"&periodos_escolares[]=MANHA"
+            f"&cemei_emei=true"
+        )
+        assert response_sem.status_code == status.HTTP_200_OK
+        results = response_sem.json()["results"]
+        assert len(results) >= 1
+        result = results[0]
+        result.pop("inclusao_id_externo")
+        assert result == {
+            "dia": "03",
+            "periodo": "MANHA",
+            "alimentacoes": "refeicao",
+            "numero_alunos": 20,
+            "dias_semana": None,
+        }
 
 
 @pytest.mark.usefixtures("client_autenticado_escola_paineis_consolidados", "escola")

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -774,7 +774,10 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         return_dict = self.inclusoes_normal_continua(
             query_set, periodos_escolares, mes, ano, return_dict
         )
-        if cemei_cei or cemei_emei:
+        excluir_continuas = (
+            request.query_params.get("excluir_inclusoes_continuas") == "true"
+        )
+        if (cemei_cei or cemei_emei) and not excluir_continuas:
             return_dict = self.inclusoes_cemei_evento_especifico(
                 mes,
                 ano,

--- a/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
+++ b/src/paineis_consolidados/solicitacoes_escola/api/viewsets.py
@@ -2,7 +2,7 @@ import datetime
 import unicodedata
 
 from dateutil.relativedelta import relativedelta
-from django.db.models import Case, IntegerField, Q, Value, When
+from django.db.models import Case, IntegerField, Max, Min, Q, Value, When
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -16,8 +16,12 @@ from src.cardapio.base.models import (
 )
 from src.cardapio.utils import ordem_periodos
 from src.dados_comuns.permissions import PermissaoParaRecuperarDietaEspecial
+from src.dados_comuns.utils import get_ultimo_dia_mes
 from src.escola.models import Escola, PeriodoEscolar
-from src.inclusao_alimentacao.models import GrupoInclusaoAlimentacaoNormal
+from src.inclusao_alimentacao.models import (
+    GrupoInclusaoAlimentacaoNormal,
+    InclusaoDeAlimentacaoCEMEI,
+)
 from src.kit_lanche.models import SolicitacaoKitLancheUnificada
 from src.medicao_inicial.models import SolicitacaoMedicaoInicial
 from src.medicao_inicial.recreio_nas_ferias.models import (
@@ -487,6 +491,8 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         ]
         for inclusao in inclusoes_cemei:
             inc = inclusao.get_raw_model.objects.get(uuid=inclusao.uuid)
+            if inc.eh_evento_especifico():
+                continue
             dias_motivos_cemei = inc.dias_motivos_da_inclusao_cemei.filter(
                 data__month=mes, data__year=ano
             )
@@ -555,6 +561,195 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
                     )
         return return_dict
 
+    def inclusoes_cemei_evento_especifico(
+        self,
+        mes,
+        ano,
+        escola_uuid,
+        periodos_escolares,
+        cemei_cei,
+        cemei_emei,
+        return_dict,
+    ):
+        primeiro_dia_mes = datetime.date(int(ano), int(mes), 1)
+        ultimo_dia_mes = get_ultimo_dia_mes(primeiro_dia_mes)
+
+        try:
+            escola = Escola.objects.get(uuid=escola_uuid)
+        except Escola.DoesNotExist:
+            return return_dict
+
+        cemei_qs = InclusaoDeAlimentacaoCEMEI.objects.filter(
+            status="CODAE_AUTORIZADO",
+            escola=escola,
+            dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico",
+            dias_motivos_da_inclusao_cemei__data__gte=primeiro_dia_mes,
+            dias_motivos_da_inclusao_cemei__data__lte=ultimo_dia_mes,
+        ).distinct()
+
+        if not cemei_qs.exists():
+            return return_dict
+
+        sol_medicao_inicial = SolicitacaoMedicaoInicial.objects.filter(
+            escola__uuid=escola_uuid, mes=mes, ano=ano
+        ).first()
+
+        for inc in cemei_qs:
+            return_dict = self._calcular_e_processar_cemei_evento(
+                inc,
+                primeiro_dia_mes,
+                ultimo_dia_mes,
+                mes,
+                ano,
+                periodos_escolares,
+                cemei_cei,
+                cemei_emei,
+                sol_medicao_inicial,
+                return_dict,
+            )
+
+        return return_dict
+
+    def _calcular_e_processar_cemei_evento(
+        self,
+        inc,
+        primeiro_dia_mes,
+        ultimo_dia_mes,
+        mes,
+        ano,
+        periodos_escolares,
+        cemei_cei,
+        cemei_emei,
+        sol_medicao_inicial,
+        return_dict,
+    ):
+        dias_motivos = inc.dias_motivos_da_inclusao_cemei.filter(
+            motivo__nome="Evento Específico"
+        )
+        if not dias_motivos.exists():
+            return return_dict
+
+        datas = dias_motivos.aggregate(data_min=Min("data"), data_max=Max("data"))
+        data_inicial = datas["data_min"]
+        data_final = datas["data_max"]
+
+        data_inicio_no_mes = max(data_inicial, primeiro_dia_mes)
+        data_fim_no_mes = min(data_final, ultimo_dia_mes)
+
+        if data_fim_no_mes < data_inicio_no_mes:
+            return return_dict
+
+        for periodo in periodos_escolares:
+            if cemei_cei:
+                return_dict = self._processa_cemei_cei_evento_especifico(
+                    periodo,
+                    inc,
+                    sol_medicao_inicial,
+                    data_inicio_no_mes,
+                    data_fim_no_mes,
+                    return_dict,
+                )
+            if cemei_emei:
+                return_dict = self._processa_cemei_emei_evento_especifico(
+                    periodo,
+                    inc,
+                    mes,
+                    ano,
+                    data_inicio_no_mes,
+                    data_fim_no_mes,
+                    return_dict,
+                )
+
+        return return_dict
+
+    def _processa_cemei_cei_evento_especifico(
+        self,
+        periodo,
+        inc,
+        sol_medicao_inicial,
+        data_inicio_no_mes,
+        data_fim_no_mes,
+        return_dict,
+    ):
+        if (
+            "Infantil" in periodo
+            or not inc.quantidade_alunos_cei_da_inclusao_cemei.exists()
+        ):
+            return return_dict
+
+        (
+            qtd_alunos_cei_cemei_por_periodo,
+            eh_parcial_integral,
+        ) = self.get_qtd_alunos_cei_cemei_por_periodo(inc, periodo, sol_medicao_inicial)
+        if not qtd_alunos_cei_cemei_por_periodo.exists():
+            return return_dict
+
+        faixas_etarias_uuids = list(
+            qtd_alunos_cei_cemei_por_periodo.values_list(
+                "faixa_etaria__uuid", flat=True
+            ).distinct()
+        )
+
+        return_dict_map = {r["dia"]: r for r in return_dict}
+
+        current = data_inicio_no_mes
+        while current <= data_fim_no_mes:
+            dia = current.day
+            if dia in return_dict_map:
+                if (
+                    return_dict_map[dia].get("eh_parcial_integral")
+                    and not eh_parcial_integral
+                ):
+                    return_dict_map[dia] = {
+                        "dia": dia,
+                        "faixas_etarias": faixas_etarias_uuids,
+                        "eh_parcial_integral": eh_parcial_integral,
+                    }
+            else:
+                return_dict_map[dia] = {
+                    "dia": dia,
+                    "faixas_etarias": faixas_etarias_uuids,
+                    "eh_parcial_integral": eh_parcial_integral,
+                }
+            current += datetime.timedelta(days=1)
+
+        return list(return_dict_map.values())
+
+    def _processa_cemei_emei_evento_especifico(
+        self,
+        periodo,
+        inc,
+        mes,
+        ano,
+        data_inicio_no_mes,
+        data_fim_no_mes,
+        return_dict,
+    ):
+        periodo_ajustado = periodo
+        if " " in periodo_ajustado:
+            periodo_ajustado = periodo_ajustado.split(" ")[1]
+
+        quantidade_emei = inc.quantidade_alunos_emei_da_inclusao_cemei.filter(
+            periodo_escolar__nome=periodo_ajustado
+        ).first()
+        if not quantidade_emei:
+            return return_dict
+
+        current = data_inicio_no_mes
+        while current <= data_fim_no_mes:
+            tratar_append_return_dict(
+                current.day,
+                mes,
+                ano,
+                quantidade_emei,
+                inc,
+                return_dict,
+                inc.escola,
+            )
+            current += datetime.timedelta(days=1)
+
+        return return_dict
+
     @action(detail=False, methods=["GET"], url_path=f"{INCLUSOES_AUTORIZADAS}")
     def inclusoes_autorizadas(self, request):
         query_set, mes, ano, escola_uuid = self.filtra_inclusoes(request)
@@ -579,6 +774,16 @@ class EscolaSolicitacoesViewSet(SolicitacoesViewSet):
         return_dict = self.inclusoes_normal_continua(
             query_set, periodos_escolares, mes, ano, return_dict
         )
+        if cemei_cei or cemei_emei:
+            return_dict = self.inclusoes_cemei_evento_especifico(
+                mes,
+                ano,
+                escola_uuid,
+                periodos_escolares,
+                cemei_cei,
+                cemei_emei,
+                return_dict,
+            )
 
         data = {"results": return_dict}
 

--- a/src/paineis_consolidados/utils/utils.py
+++ b/src/paineis_consolidados/utils/utils.py
@@ -4,17 +4,11 @@ import unicodedata
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
 
-from src.cardapio.base.models import (
-    VinculoTipoAlimentacaoComPeriodoEscolarETipoUnidadeEscolar,
-)
 from src.dados_comuns.utils import get_ultimo_dia_mes
 from src.dieta_especial.solicitacao_dieta_especial.models import (
     SolicitacaoDietaEspecial,
 )
 from src.escola.models import DiretoriaRegional, Lote
-from src.inclusao_alimentacao.models import (
-    QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI,
-)
 from src.terceirizada.models import Terceirizada
 
 
@@ -140,15 +134,9 @@ def tratar_append_return_dict(dia, mes, ano, periodo, inclusao, return_dict, esc
         or dia < datetime.date.today().day
         or (escola.ultimo_dia_letivo and dia == escola.ultimo_dia_letivo.day)
     ):
-        if isinstance(periodo, QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI):
-            queryset_tipos_alimentacao = (
-                VinculoTipoAlimentacaoComPeriodoEscolarETipoUnidadeEscolar.objects.get(
-                    tipo_unidade_escolar__iniciais="EMEI",
-                    periodo_escolar=periodo.periodo_escolar,
-                ).tipos_alimentacao.exclude(nome="Lanche Emergencial")
-            )
-        else:
-            queryset_tipos_alimentacao = periodo.tipos_alimentacao.all()
+        queryset_tipos_alimentacao = periodo.tipos_alimentacao.exclude(
+            nome="Lanche Emergencial"
+        )
         alimentacoes = ", ".join(
             [
                 unicodedata.normalize("NFD", alimentacao.nome.replace(" ", "_"))

--- a/src/recebimento/ajuste_saldo_laudo/api/viewsets.py
+++ b/src/recebimento/ajuste_saldo_laudo/api/viewsets.py
@@ -57,7 +57,6 @@ class AjusteSaldoModelViewSet(ViewSetActionPermissionMixin, viewsets.ModelViewSe
 
         Cria um novo ajuste de Saldo de Laudo
         """
-        print(request.data)
         serializer = AjusteSaldoCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()


### PR DESCRIPTION
# Este PR:
- altera endpoints relacionados a inclusão contínua para escolas CEMEI:
  - quando há uma Inclusão CEMEI com motivo Evento Específico, ela será lançada na medição inicial no bloco de Programas e Projetos
- altera algoritmo de finalização de medição para CEMEI:
  - para programas e projetos, inclui a inclusão normal com evento específico
  - para lançamento de períodos escolares, exclui a inclusão normal com evento específico
- adiciona NOITE nos vínculos de EMEI por causa do Evento Específico
- adiciona testes unitários para os ajustes

### Referência azure:
- [AB#152286](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152286)