### PR TITLE
Feature/152495 altera regra total pagamentos recreio

### DIFF
--- a/src/medicao_inicial/utils.py
+++ b/src/medicao_inicial/utils.py
@@ -1239,7 +1239,7 @@ def build_tabela_colaboradores_cei(solicitacao, medicao_colaboradores):
             soma_ref = valores_dia.get("refeicao", 0) + valores_dia.get(
                 "repeticao_refeicao", 0
             )
-            pgto_ref = min(soma_ref, participantes)
+            pgto_ref = soma_ref
             total_pgto_refeicao += pgto_ref
 
         pgto_sob = 0
@@ -1247,7 +1247,7 @@ def build_tabela_colaboradores_cei(solicitacao, medicao_colaboradores):
             soma_sob = valores_dia.get("sobremesa", 0) + valores_dia.get(
                 "repeticao_sobremesa", 0
             )
-            pgto_sob = min(soma_sob, participantes)
+            pgto_sob = soma_sob
             total_pgto_sobremesa += pgto_sob
 
         linha = _cei_colaboradores_linha_dia(
@@ -1899,6 +1899,97 @@ def get_numero_campos(tabela, periodo_corrente, categoria_corrente):
     return indice_inicial, indice_final
 
 
+def _resolver_contexto_tabela_anterior(
+    tabela,
+    periodo_corrente,
+    categoria_corrente,
+    dia,
+    valores_dia,
+    tabelas,
+    indice_tabela,
+):
+    indice_inicial, indice_final = get_numero_campos(
+        tabela, periodo_corrente, categoria_corrente
+    )
+    campos = tabela["nomes_campos"][indice_inicial:indice_final]
+    valores = valores_dia[indice_inicial + 1 : indice_final + 1]
+
+    tabela_anterior = tabelas[indice_tabela - 1]
+    campos_tabela_anterior = []
+    valores_tabela_anterior = []
+    if (
+        indice_tabela > 0
+        and periodo_corrente in tabela_anterior["periodos"]
+        and categoria_corrente in tabela_anterior["categorias"]
+    ):
+        ia, ib = get_numero_campos(
+            tabela_anterior, periodo_corrente, categoria_corrente
+        )
+        campos_tabela_anterior = tabela_anterior["nomes_campos"][ia:ib]
+        valores_tabela_anterior = tabela_anterior["valores_campos"][int(dia - 1)][
+            ia + 1 : ib + 1
+        ]
+    return (
+        campos,
+        campos_tabela_anterior,
+        valores,
+        valores_tabela_anterior,
+        tabela_anterior,
+    )
+
+
+def _obter_valor_campo_ctx(ctx, indice_periodo, tabela, nome_campo):
+    campos, campos_ta, valores, valores_ta, tabela_anterior = ctx
+    return get_valor_campo(
+        campos,
+        campos_ta,
+        indice_periodo,
+        tabela,
+        tabela_anterior,
+        valores,
+        valores_ta,
+        nome_campo,
+    )
+
+
+def _get_valor_comparativo(
+    valor_matriculados, valor_numero_de_alunos, valor_participantes
+):
+    if int(valor_matriculados) > 0:
+        return valor_matriculados
+    if int(valor_numero_de_alunos) > 0:
+        return valor_numero_de_alunos
+    return valor_participantes
+
+
+def _calcular_total_pagamento(
+    valor_principal,
+    valor_repeticao,
+    valor_segunda,
+    valor_repeticao_segunda,
+    valor_comparativo,
+    eh_colaboradores,
+):
+    total = int(valor_principal) + int(valor_repeticao)
+    total_2a = int(valor_segunda) + int(valor_repeticao_segunda)
+    if not eh_colaboradores:
+        total = min(total, int(valor_comparativo))
+        total_2a = min(total_2a, int(valor_comparativo))
+    return total + total_2a
+
+
+def _eh_emei_ou_cemei_ou_infantil(solicitacao, tabela, indice_periodo):
+    eh_emebs_infantil = (
+        solicitacao.escola.eh_emebs_data(solicitacao.data_referencia)
+        and tabela["periodos"][indice_periodo].split(" - ")[1] == "INFANTIL"
+    )
+    return (
+        solicitacao.escola.eh_emei_data(solicitacao.data_referencia)
+        or solicitacao.escola.eh_cemei_data(solicitacao.data_referencia)
+        or eh_emebs_infantil
+    )
+
+
 def popula_campo_total_refeicoes_pagamento(
     solicitacao,
     tabela,
@@ -1909,149 +2000,71 @@ def popula_campo_total_refeicoes_pagamento(
     tabelas,
     indice_tabela,
 ):
-    if campo == "total_refeicoes_pagamento":
-        try:
-            periodo_corrente = tabela["periodos"][indice_periodo]
-            indice_inicial, indice_final = get_numero_campos(
-                tabela, periodo_corrente, categoria_corrente
-            )
-            dia = valores_dia[0]
-            campos = tabela["nomes_campos"][indice_inicial:indice_final]
-            valores = valores_dia[indice_inicial + 1 : indice_final + 1]
-            tabela_anterior = tabelas[indice_tabela - 1]
-            periodos_tabela_anterior = tabela_anterior["periodos"]
-            campos_tabela_anterior = []
-            valores_tabela_anterior = []
-            if (
-                indice_tabela > 0
-                and periodo_corrente in periodos_tabela_anterior
-                and categoria_corrente in tabela_anterior["categorias"]
-            ):
-                (
-                    indice_inicial_tabela_anterior,
-                    indice_final_tabela_anterior,
-                ) = get_numero_campos(
-                    tabela_anterior, periodo_corrente, categoria_corrente
-                )
-                campos_tabela_anterior = tabela_anterior["nomes_campos"][
-                    indice_inicial_tabela_anterior:indice_final_tabela_anterior
-                ]
-                valores_tabela_anterior = tabela_anterior["valores_campos"][
-                    int(dia - 1)
-                ][indice_inicial_tabela_anterior + 1 : indice_final_tabela_anterior + 1]
-            valor_refeicao = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "refeicao",
-            )
-            valor_repeticao_refeicao = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "repeticao_refeicao",
-            )
-            valor_segunda_refeicao = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "2_refeicao_1_oferta",
-            )
-            valor_repeticao_segunda_refeicao = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "repeticao_2_refeicao",
-            )
-            valor_matriculados = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "matriculados",
-            )
-            valor_numero_de_alunos = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "numero_de_alunos",
-            )
-            valor_participantes = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "participantes",
-            )
-            eh_emebs_infantil = (
-                solicitacao.escola.eh_emebs_data(solicitacao.data_referencia)
-                and tabela["periodos"][indice_periodo].split(" - ")[1] == "INFANTIL"
-            )
-            eh_colaboradores = "Colaboradores" in periodo_corrente
-            if not eh_colaboradores and (
-                solicitacao.escola.eh_emei_data(solicitacao.data_referencia)
-                or solicitacao.escola.eh_cemei_data(solicitacao.data_referencia)
-                or eh_emebs_infantil
-            ):
-                valores_dia = get_valor_total_emei_cemei(
-                    solicitacao,
-                    valores_dia,
-                    valor_refeicao,
-                    valor_repeticao_refeicao,
-                    valor_segunda_refeicao,
-                    valor_repeticao_segunda_refeicao,
-                    valor_matriculados,
-                    valor_numero_de_alunos,
-                    valor_participantes,
-                )
-            else:
-                valor_comparativo = (
-                    valor_matriculados
-                    if int(valor_matriculados) > 0
-                    else (
-                        valor_numero_de_alunos
-                        if int(valor_numero_de_alunos) > 0
-                        else valor_participantes
-                    )
-                )
-                total_refeicao = int(valor_refeicao) + int(valor_repeticao_refeicao)
-                total_refeicao = min(int(total_refeicao), int(valor_comparativo))
+    if campo != "total_refeicoes_pagamento":
+        return
+    try:
+        periodo_corrente = tabela["periodos"][indice_periodo]
+        dia = valores_dia[0]
+        ctx = _resolver_contexto_tabela_anterior(
+            tabela,
+            periodo_corrente,
+            categoria_corrente,
+            dia,
+            valores_dia,
+            tabelas,
+            indice_tabela,
+        )
 
-                total_refeicao_2a_oferta = int(valor_segunda_refeicao) + int(
-                    valor_repeticao_segunda_refeicao
-                )
-                total_refeicao_2a_oferta = min(
-                    int(total_refeicao_2a_oferta), int(valor_comparativo)
-                )
-                valores_dia += [total_refeicao + total_refeicao_2a_oferta]
-        except Exception:
-            valores_dia += ["0"]
+        v_refeicao = _obter_valor_campo_ctx(ctx, indice_periodo, tabela, "refeicao")
+        v_repeticao_refeicao = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "repeticao_refeicao"
+        )
+        v_segunda_refeicao = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "2_refeicao_1_oferta"
+        )
+        v_repeticao_segunda = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "repeticao_2_refeicao"
+        )
+        v_matriculados = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "matriculados"
+        )
+        v_numero_alunos = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "numero_de_alunos"
+        )
+        v_participantes = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "participantes"
+        )
+
+        eh_colaboradores = "Colaboradores" in periodo_corrente
+        if not eh_colaboradores and _eh_emei_ou_cemei_ou_infantil(
+            solicitacao, tabela, indice_periodo
+        ):
+            valores_dia = get_valor_total_emei_cemei(
+                solicitacao,
+                valores_dia,
+                v_refeicao,
+                v_repeticao_refeicao,
+                v_segunda_refeicao,
+                v_repeticao_segunda,
+                v_matriculados,
+                v_numero_alunos,
+                v_participantes,
+            )
+        else:
+            valor_comparativo = _get_valor_comparativo(
+                v_matriculados, v_numero_alunos, v_participantes
+            )
+            total = _calcular_total_pagamento(
+                v_refeicao,
+                v_repeticao_refeicao,
+                v_segunda_refeicao,
+                v_repeticao_segunda,
+                valor_comparativo,
+                eh_colaboradores,
+            )
+            valores_dia += [total]
+    except Exception:
+        valores_dia += ["0"]
 
 
 def get_valor_total_emei_cemei(
@@ -2153,160 +2166,71 @@ def popula_campo_total_sobremesas_pagamento(
     tabelas,
     indice_tabela,
 ):
-    if campo == "total_sobremesas_pagamento":
-        try:
-            periodo_corrente = tabela["periodos"][indice_periodo]
-            indice_inicial, indice_final = get_numero_campos(
-                tabela, periodo_corrente, categoria_corrente
+    if campo != "total_sobremesas_pagamento":
+        return
+    try:
+        periodo_corrente = tabela["periodos"][indice_periodo]
+        dia = valores_dia[0]
+        ctx = _resolver_contexto_tabela_anterior(
+            tabela,
+            periodo_corrente,
+            categoria_corrente,
+            dia,
+            valores_dia,
+            tabelas,
+            indice_tabela,
+        )
+
+        v_sobremesa = _obter_valor_campo_ctx(ctx, indice_periodo, tabela, "sobremesa")
+        v_repeticao_sobremesa = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "repeticao_sobremesa"
+        )
+        v_segunda_sobremesa = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "2_sobremesa_1_oferta"
+        )
+        v_repeticao_segunda = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "repeticao_2_sobremesa"
+        )
+        v_matriculados = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "matriculados"
+        )
+        v_numero_alunos = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "numero_de_alunos"
+        )
+        v_participantes = _obter_valor_campo_ctx(
+            ctx, indice_periodo, tabela, "participantes"
+        )
+
+        eh_colaboradores = "Colaboradores" in periodo_corrente
+        if not eh_colaboradores and _eh_emei_ou_cemei_ou_infantil(
+            solicitacao, tabela, indice_periodo
+        ):
+            valores_dia = get_valor_total_emei_cemei(
+                solicitacao,
+                valores_dia,
+                v_sobremesa,
+                v_repeticao_sobremesa,
+                v_segunda_sobremesa,
+                v_repeticao_segunda,
+                v_matriculados,
+                v_numero_alunos,
+                v_participantes,
             )
-            dia = valores_dia[0]
-            campos = tabela["nomes_campos"][indice_inicial:indice_final]
-            valores = valores_dia[indice_inicial + 1 : indice_final + 1]
-            tabela_anterior = tabelas[indice_tabela - 1]
-            periodos_tabela_anterior = tabela_anterior["periodos"]
-            campos_tabela_anterior = []
-            valores_tabela_anterior = []
-            if (
-                indice_tabela > 0
-                and periodo_corrente in periodos_tabela_anterior
-                and categoria_corrente in tabela_anterior["categorias"]
-            ):
-                (
-                    indice_inicial_tabela_anterior,
-                    indice_final_tabela_anterior,
-                ) = get_numero_campos(
-                    tabela_anterior, periodo_corrente, categoria_corrente
-                )
-                campos_tabela_anterior = tabela_anterior["nomes_campos"][
-                    indice_inicial_tabela_anterior:indice_final_tabela_anterior
-                ]
-                valores_tabela_anterior = tabela_anterior["valores_campos"][
-                    int(dia - 1)
-                ][indice_inicial_tabela_anterior + 1 : indice_final_tabela_anterior + 1]
-
-            valor_sobremesa = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "sobremesa",
+        else:
+            valor_comparativo = _get_valor_comparativo(
+                v_matriculados, v_numero_alunos, v_participantes
             )
-
-            valor_repeticao_sobremesa = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "repeticao_sobremesa",
+            total = _calcular_total_pagamento(
+                v_sobremesa,
+                v_repeticao_sobremesa,
+                v_segunda_sobremesa,
+                v_repeticao_segunda,
+                valor_comparativo,
+                eh_colaboradores,
             )
-
-            valor_segunda_sobremesa = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "2_sobremesa_1_oferta",
-            )
-
-            valor_repeticao_segunda_sobremesa = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "repeticao_2_sobremesa",
-            )
-
-            valor_matriculados = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "matriculados",
-            )
-
-            valor_numero_de_alunos = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "numero_de_alunos",
-            )
-
-            valor_participantes = get_valor_campo(
-                campos,
-                campos_tabela_anterior,
-                indice_periodo,
-                tabela,
-                tabela_anterior,
-                valores,
-                valores_tabela_anterior,
-                "participantes",
-            )
-
-            eh_emebs_infantil = (
-                solicitacao.escola.eh_emebs_data(solicitacao.data_referencia)
-                and tabela["periodos"][indice_periodo].split(" - ")[1] == "INFANTIL"
-            )
-
-            eh_colaboradores = "Colaboradores" in periodo_corrente
-            if not eh_colaboradores and (
-                solicitacao.escola.eh_emei_data(solicitacao.data_referencia)
-                or solicitacao.escola.eh_cemei_data(solicitacao.data_referencia)
-                or eh_emebs_infantil
-            ):
-                valores_dia = get_valor_total_emei_cemei(
-                    solicitacao,
-                    valores_dia,
-                    valor_sobremesa,
-                    valor_repeticao_sobremesa,
-                    valor_segunda_sobremesa,
-                    valor_repeticao_segunda_sobremesa,
-                    valor_matriculados,
-                    valor_numero_de_alunos,
-                    valor_participantes,
-                )
-            else:
-                valor_comparativo = (
-                    valor_matriculados
-                    if int(valor_matriculados) > 0
-                    else (
-                        valor_numero_de_alunos
-                        if int(valor_numero_de_alunos) > 0
-                        else valor_participantes
-                    )
-                )
-
-                total_sobremesa = int(valor_sobremesa) + int(valor_repeticao_sobremesa)
-                total_sobremesa = min(int(total_sobremesa), int(valor_comparativo))
-
-                total_sobremesa_2a_oferta = int(valor_segunda_sobremesa) + int(
-                    valor_repeticao_segunda_sobremesa
-                )
-                total_sobremesa_2a_oferta = min(
-                    int(total_sobremesa_2a_oferta), int(valor_comparativo)
-                )
-
-                valores_dia += [total_sobremesa + total_sobremesa_2a_oferta]
-        except Exception:
-            valores_dia += ["0"]
+            valores_dia += [total]
+    except Exception:
+        valores_dia += ["0"]
 
 
 def popula_solicitado_total_lanche_emergencial(
@@ -4866,7 +4790,7 @@ def build_valores_campos(solicitacao, tabela):  # noqa C901
 
 
 def _calcular_pgto_colaboradores(principal, repeticao, participantes):
-    return min(int(principal) + int(repeticao), int(participantes))
+    return int(principal) + int(repeticao)
 
 
 def _calcular_pgto_refeicao_sobremesa(medicao_colaboradores, dias):

--- a/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_cei_medicao_recreio_nas_ferias.py
+++ b/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_cei_medicao_recreio_nas_ferias.py
@@ -121,8 +121,8 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasCEI:
     def _setup_logs_colaboradores(self, valor_medicao_factory):
         # 4 dias:
         # lanche = 5/dia => 20
-        # refeicao pgto = min(3 + 4, 5) = 5/dia => 20
-        # sobremesa pgto = min(2 + 5, 5) = 5/dia => 20
+        # refeicao pgto = 3 + 4 = 7/dia => 28
+        # sobremesa pgto = 2 + 5 = 7/dia => 28
         for dia in range(7, 11):
             campos_valores = {
                 "participantes": "5",
@@ -164,9 +164,7 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasCEI:
         assert any(
             item.get("periodos") == ["Recreio nas Férias"] for item in build_tabelas
         )
-        assert any(
-            item.get("periodos") == ["Colaboradores"] for item in build_tabelas
-        )
+        assert any(item.get("periodos") == ["Colaboradores"] for item in build_tabelas)
 
         dict_total_refeicoes = get_total_por_periodo(
             build_tabelas, "total_refeicoes_pagamento"
@@ -175,12 +173,10 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasCEI:
             build_tabelas, "total_sobremesas_pagamento"
         )
 
-        assert dict_total_refeicoes["Colaboradores"] == 20
-        assert dict_total_sobremesas["Colaboradores"] == 20
+        assert dict_total_refeicoes["Colaboradores"] == 28
+        assert dict_total_sobremesas["Colaboradores"] == 28
 
-        somatorio = build_tabela_somatorio_body_cei_recreio_nas_ferias(
-            self.solicitacao
-        )
+        somatorio = build_tabela_somatorio_body_cei_recreio_nas_ferias(self.solicitacao)
 
         assert somatorio["tabela_alimentacao"] == {
             "header": [
@@ -205,8 +201,8 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasCEI:
             ],
             "valores_campos": [
                 ["Lanche", "20"],
-                ["Refeição", "20"],
-                ["Sobremesa", "20"],
+                ["Refeição", "28"],
+                ["Sobremesa", "28"],
             ],
             "legenda": "*A tabela acima representa a soma das alimentações lançadas para os colaboradores em Recreio nas Férias - 01/2026",
         }
@@ -244,9 +240,7 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasCEI:
                 faixa_etaria=self.faixa_2,
             )
 
-        somatorio = build_tabela_somatorio_body_cei_recreio_nas_ferias(
-            self.solicitacao
-        )
+        somatorio = build_tabela_somatorio_body_cei_recreio_nas_ferias(self.solicitacao)
 
         tabela_alimentacao = somatorio["tabela_alimentacao"]
 

--- a/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_cemei_medicao_recreio_nas_ferias.py
+++ b/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_cemei_medicao_recreio_nas_ferias.py
@@ -153,8 +153,8 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasCEMEI:
     def _setup_logs_colaboradores(self, valor_medicao_factory):
         # 4 dias:
         # lanche = 5/dia => 20
-        # refeicao pgto = min(3 + 4, 5) = 5/dia => 20
-        # sobremesa pgto = min(2 + 5, 5) = 5/dia => 20
+        # refeicao pgto = 3 + 4 = 7/dia => 28
+        # sobremesa pgto = 2 + 5 = 7/dia => 28
         for dia in range(7, 11):
             for nome_campo, valor in {
                 "participantes": "5",
@@ -238,8 +238,8 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasCEMEI:
             ],
             "valores_campos": [
                 ["Lanche", "20"],
-                ["Refeição", "20"],
-                ["Sobremesa", "20"],
+                ["Refeição", "28"],
+                ["Sobremesa", "28"],
             ],
             "legenda": "*A tabela acima representa a soma das alimentações lançadas para os colaboradores em Recreio nas Férias - 01/2026",
         }

--- a/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_medicao_recreio_nas_ferias.py
+++ b/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_medicao_recreio_nas_ferias.py
@@ -242,7 +242,7 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFerias:
         )
         assert dict_total_refeicoes == {
             "Recreio nas Férias": 40,
-            "Colaboradores": 20,
+            "Colaboradores": 40,
         }
 
         dict_total_sobremesas = get_total_por_periodo(
@@ -250,7 +250,7 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFerias:
         )
         assert dict_total_sobremesas == {
             "Recreio nas Férias": 40,
-            "Colaboradores": 20,
+            "Colaboradores": 44,
         }
 
         # --- somatorio recreio ---
@@ -276,8 +276,8 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFerias:
         }
 
         # lanche=5 × 4 dias = 20, lanche_4h=20,
-        # refeicao=min(3+7, 5) × 4 dias = 20 (soma refeicao + repeticao_refeicao),
-        # sobremesa=min(2+9, 5) × 4 dias = 20 (soma sobremesa + repeticao_sobremesa)
+        # refeicao=(3+7) × 4 dias = 40 (soma simples para colaboradores),
+        # sobremesa=(2+9) × 4 dias = 44 (soma simples para colaboradores)
         assert tabela_somatorio_colaboradores == {
             "header": [
                 "TIPOS ALIMENTAÇÃO",
@@ -286,8 +286,8 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFerias:
             "body": [
                 ["Lanche", 20],
                 ["Lanche 4h", 20],
-                ["Refeição", 20],
-                ["Sobremesa", 20],
+                ["Refeição", 40],
+                ["Sobremesa", 44],
             ],
         }
 
@@ -615,9 +615,9 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasEMEI:
         assert dict_total_refeicoes["Recreio nas Férias"] == 32
         # Sem IMR: sobremesa=8 × 4 dias = 32 (repeticao ignorada)
         assert dict_total_sobremesas["Recreio nas Férias"] == 32
-        # Colaboradores sempre usa o else (sem IMR check): min(5+5, 5) × 4 = 20
-        assert dict_total_refeicoes["Colaboradores"] == 20
-        assert dict_total_sobremesas["Colaboradores"] == 20
+        # Colaboradores: soma simples (5+5) × 4 = 40
+        assert dict_total_refeicoes["Colaboradores"] == 40
+        assert dict_total_sobremesas["Colaboradores"] == 40
 
     @freeze_time("2026-01-10")
     def test_emei_com_imr_aplica_min_na_refeicao(
@@ -674,6 +674,6 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFeriasEMEI:
         assert dict_total_refeicoes["Recreio nas Férias"] == 40
         # Com IMR: min(8 + 6, 10) = 10 × 4 dias = 40
         assert dict_total_sobremesas["Recreio nas Férias"] == 40
-        # Colaboradores usa else (sem IMR check): min(5+5, 5) × 4 = 20
-        assert dict_total_refeicoes["Colaboradores"] == 20
-        assert dict_total_sobremesas["Colaboradores"] == 20
+        # Colaboradores: soma simples (5+5) × 4 = 40
+        assert dict_total_refeicoes["Colaboradores"] == 40
+        assert dict_total_sobremesas["Colaboradores"] == 40

--- a/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_medicao_recreio_nas_ferias.py
+++ b/src/relatorios/__tests__/test_relatorios/test_relatorio_pdf_escola_medicao_recreio_nas_ferias.py
@@ -150,19 +150,19 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFerias:
 
     def _setup_logs_medicao_colaboradores_alimentacao(self, valor_medicao_factory):
         for dia in range(7, 11):
-            for nome_campo in [
-                "participantes",
-                "frequencia",
-                "lanche",
-                "lanche_4h",
-                "refeicao",
-                "repeticao_refeicao",
-                "sobremesa",
-                "repeticao_sobremesa",
+            for nome_campo, valor in [
+                ("participantes", "5"),
+                ("frequencia", "5"),
+                ("lanche", "5"),
+                ("lanche_4h", "5"),
+                ("refeicao", "3"),
+                ("repeticao_refeicao", "7"),
+                ("sobremesa", "2"),
+                ("repeticao_sobremesa", "9"),
             ]:
                 valor_medicao_factory.create(
                     dia=f"{dia:02d}",
-                    valor="5",
+                    valor=valor,
                     nome_campo=nome_campo,
                     medicao=self.medicao_colaboradores,
                     categoria_medicao=self.categoria_alimentacao,
@@ -275,7 +275,9 @@ class TestUseCaseRelatorioPDFMedicaoEscolaRecreioNasFerias:
             ],
         }
 
-        # lanche=5 × 4 dias = 20, lanche_4h=20, refeicao=20, sobremesa=20
+        # lanche=5 × 4 dias = 20, lanche_4h=20,
+        # refeicao=min(3+7, 5) × 4 dias = 20 (soma refeicao + repeticao_refeicao),
+        # sobremesa=min(2+9, 5) × 4 dias = 20 (soma sobremesa + repeticao_sobremesa)
         assert tabela_somatorio_colaboradores == {
             "header": [
                 "TIPOS ALIMENTAÇÃO",


### PR DESCRIPTION
# Este PR:
- altera regra para total de pagamento de colaboradores - Recreio nas Férias
- complementa os testes unitários para garantir o funcionamento da regra:
  - total de pagamento dos Colaboradores, em medições de Recreio nas Férias
  - total de refeições: refeição + repetição refeição (mesmo que repetição é maior que refeição)
  - total de sobremesas: sobremesa + repetição sobremesa (mesmo que repetição é maior que sobremesa)

### Referência azure:
- [AB#152495](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/152495)

<img width="1209" height="398" alt="Screenshot from 2026-07-06 15-03-22" src="https://github.com/user-attachments/assets/29bc4f9e-bc7f-4a95-9161-1e23908c8a5e" />
