### PR TITLE
Feature/150971 painel de aprovacoes exibir cronogramas cadastrados em verde

### DIFF
--- a/src/pre_recebimento/__tests__/test_serializers.py
+++ b/src/pre_recebimento/__tests__/test_serializers.py
@@ -26,6 +26,7 @@ from src.pre_recebimento.cronograma_entrega.api.serializers.serializers import (
     InterrupcaoProgramadaEntregaSerializer,
     PainelCronogramaSerializer,
     SolicitacaoAlteracaoCronogramaSerializer,
+    PainelSolicitacaoAlteracaoCronogramaSerializerItem,
 )
 from src.pre_recebimento.cronograma_entrega.models import (
     Cronograma,
@@ -674,3 +675,25 @@ def test_ficha_tecnica_simples_serializer_expoe_ponto_a_ponto():
 
     assert dados["ponto_a_ponto"] is True
     assert "flv_ponto_a_ponto" not in dados
+
+
+def test_painel_solicitacao_alteracao_cronograma_serializer_retorna_ponto_a_ponto(cronograma_assinado_perfil_dilog):
+    cronograma = cronograma_assinado_perfil_dilog
+    cronograma.ficha_tecnica.tipo_entrega = FichaTecnicaDoProduto.PONTO_A_PONTO
+    cronograma.ficha_tecnica.save()
+
+    solicitacao = baker.make(
+        "SolicitacaoAlteracaoCronograma",
+        cronograma=cronograma,
+        status="EM_ANALISE",
+    )
+
+    solicitacao.log_criado_em = timezone.now()
+
+    serializer = PainelSolicitacaoAlteracaoCronogramaSerializerItem(solicitacao)
+    data = serializer.data
+
+    assert "ponto_a_ponto" in data
+    assert data["ponto_a_ponto"] is True
+    assert data["cronograma"] == cronograma.numero
+    assert data["produto"] == cronograma.ficha_tecnica.produto.nome

--- a/src/pre_recebimento/cronograma_entrega/api/serializers/serializers.py
+++ b/src/pre_recebimento/cronograma_entrega/api/serializers/serializers.py
@@ -798,6 +798,7 @@ class PainelCronogramaSerializer(serializers.ModelSerializer):
     log_mais_recente = serializers.SerializerMethodField()
     status = serializers.CharField(source="get_status_display")
     programa_leve_leite = serializers.SerializerMethodField()
+    ponto_a_ponto = serializers.BooleanField(read_only=True)
 
     def get_produto(self, obj):
         try:
@@ -836,6 +837,7 @@ class PainelCronogramaSerializer(serializers.ModelSerializer):
             "produto",
             "log_mais_recente",
             "programa_leve_leite",
+            "ponto_a_ponto",
         )
 
 
@@ -846,6 +848,7 @@ class PainelSolicitacaoAlteracaoCronogramaSerializerItem(serializers.ModelSerial
     status = serializers.CharField(source="get_status_display")
     log_mais_recente = serializers.SerializerMethodField()
     programa_leve_leite = serializers.SerializerMethodField()
+    ponto_a_ponto = serializers.SerializerMethodField()
 
     def get_produto(self, obj):
         try:
@@ -867,6 +870,11 @@ class PainelSolicitacaoAlteracaoCronogramaSerializerItem(serializers.ModelSerial
         except AttributeError:
             return None
 
+    def get_ponto_a_ponto(self, obj):
+        try:
+            return obj.cronograma.ponto_a_ponto
+        except AttributeError:
+            return False
     class Meta:
         model = SolicitacaoAlteracaoCronograma
         fields = (
@@ -878,6 +886,7 @@ class PainelSolicitacaoAlteracaoCronogramaSerializerItem(serializers.ModelSerial
             "produto",
             "log_mais_recente",
             "programa_leve_leite",
+            "ponto_a_ponto"    
         )
 
 

--- a/src/pre_recebimento/cronograma_entrega/api/serializers/serializers.py
+++ b/src/pre_recebimento/cronograma_entrega/api/serializers/serializers.py
@@ -875,6 +875,7 @@ class PainelSolicitacaoAlteracaoCronogramaSerializerItem(serializers.ModelSerial
             return obj.cronograma.ponto_a_ponto
         except AttributeError:
             return False
+
     class Meta:
         model = SolicitacaoAlteracaoCronograma
         fields = (
@@ -886,7 +887,7 @@ class PainelSolicitacaoAlteracaoCronogramaSerializerItem(serializers.ModelSerial
             "produto",
             "log_mais_recente",
             "programa_leve_leite",
-            "ponto_a_ponto"    
+            "ponto_a_ponto",
         )
 
 


### PR DESCRIPTION
 ### Referência azure:
- [AB#150971](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/150971)

### Alterações 

Foi ajustado os serializers utilizados no  **Painel de Aprovações** para retornar o campo `ponto_a_ponto`.