### PR TITLE
Hotfix/152528 nao permite envio sem ultimo dia letivo

### DIFF
--- a/src/medicao_inicial/__tests__/test_validators/test_validate_ultimo_dia_mes_letivo.py
+++ b/src/medicao_inicial/__tests__/test_validators/test_validate_ultimo_dia_mes_letivo.py
@@ -47,8 +47,10 @@ def _setup_solicitacao(
     return solicitacao
 
 
-def _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia):
+def _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia, escola=None):
     periodo = periodo_escolar_factory.create(nome="MANHA")
+    if escola:
+        _tornar_escola_com_alunos_regulares(escola, periodo)
     medicao = Medicao.objects.create(
         solicitacao_medicao_inicial=solicitacao,
         periodo_escolar=periodo,
@@ -63,6 +65,20 @@ def _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia):
             valor="10",
         )
     return medicao
+
+
+def _tornar_escola_com_alunos_regulares(escola, periodo):
+    from src.escola.models import AlunosMatriculadosPeriodoEscola
+
+    if not AlunosMatriculadosPeriodoEscola.objects.filter(
+        escola=escola, periodo_escolar=periodo
+    ).exists():
+        AlunosMatriculadosPeriodoEscola.objects.create(
+            escola=escola,
+            periodo_escolar=periodo,
+            quantidade_alunos=10,
+            tipo_turma="REGULAR",
+        )
 
 
 class TestValidateUltimoDiaMesLetivo:
@@ -84,7 +100,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -112,7 +130,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -135,7 +155,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=False,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -157,7 +179,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=None,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -180,7 +204,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_emei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -204,7 +230,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_emei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -227,7 +255,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_cemei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -251,7 +281,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_cemei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -274,7 +306,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_cei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -298,7 +332,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_cei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -326,7 +362,7 @@ class TestValidateUltimoDiaMesLetivo:
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
 
-        assert len(result) == 1
+        assert len(result) == 0
 
     def test_ceu_gestao_ultimo_dia_letivo_com_preenchimento(
         self,
@@ -368,7 +404,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_emebs
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -392,7 +430,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_emebs
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -418,6 +458,8 @@ class TestValidateUltimoDiaMesLetivo:
         )
         periodo_manha = periodo_escolar_factory.create(nome="MANHA")
         periodo_tarde = periodo_escolar_factory.create(nome="TARDE")
+        _tornar_escola_com_alunos_regulares(escola, periodo_manha)
+        _tornar_escola_com_alunos_regulares(escola, periodo_tarde)
         categoria = CategoriaMedicao.objects.create(nome="ALIMENTAÇÃO")
         for periodo in [periodo_manha, periodo_tarde]:
             medicao = Medicao.objects.create(
@@ -460,7 +502,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -566,7 +610,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_cieja
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -590,7 +636,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_cieja
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -613,7 +661,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_cmct
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -637,7 +687,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_cmct
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -660,7 +712,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_ceu_cemei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -684,7 +738,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_ceu_cemei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -707,7 +763,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_ceu_emei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -731,7 +789,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_ceu_emei
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -754,7 +814,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=None, escola=escola_cci
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
@@ -778,7 +840,9 @@ class TestValidateUltimoDiaMesLetivo:
             ano,
             ultimo_dia_eh_letivo=True,
         )
-        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        _cria_medicao_e_valores(
+            solicitacao, periodo_escolar_factory, dia=ultimo, escola=escola_cci
+        )
         lista_erros = []
 
         result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)

--- a/src/medicao_inicial/__tests__/test_validators/test_validate_ultimo_dia_mes_letivo.py
+++ b/src/medicao_inicial/__tests__/test_validators/test_validate_ultimo_dia_mes_letivo.py
@@ -1,0 +1,786 @@
+import calendar
+import datetime
+
+import pytest
+
+from src.medicao_inicial.models import (
+    CategoriaMedicao,
+    Medicao,
+    ValorMedicao,
+)
+from src.medicao_inicial.validators import validate_ultimo_dia_mes_letivo
+
+pytestmark = pytest.mark.django_db
+
+
+def _get_mes_ano():
+    return 4, 2025
+
+
+def _ultimo_dia(mes, ano):
+    return calendar.monthrange(ano, mes)[1]
+
+
+def _dia_str(dia):
+    return f"{dia:02d}"
+
+
+def _setup_solicitacao(
+    solicitacao_medicao_inicial_factory,
+    dia_calendario_factory,
+    escola,
+    mes,
+    ano,
+    ultimo_dia_eh_letivo,
+):
+    solicitacao = solicitacao_medicao_inicial_factory.create(
+        escola=escola,
+        mes=f"{mes:02d}",
+        ano=str(ano),
+    )
+    if ultimo_dia_eh_letivo is not None:
+        dia_calendario_factory.create(
+            escola=escola,
+            data=datetime.date(ano, mes, _ultimo_dia(mes, ano)),
+            dia_letivo=ultimo_dia_eh_letivo,
+        )
+    return solicitacao
+
+
+def _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia):
+    periodo = periodo_escolar_factory.create(nome="MANHA")
+    medicao = Medicao.objects.create(
+        solicitacao_medicao_inicial=solicitacao,
+        periodo_escolar=periodo,
+    )
+    if dia is not None:
+        categoria = CategoriaMedicao.objects.create(nome="ALIMENTAÇÃO")
+        ValorMedicao.objects.create(
+            medicao=medicao,
+            categoria_medicao=categoria,
+            dia=_dia_str(dia),
+            nome_campo="lanche",
+            valor="10",
+        )
+    return medicao
+
+
+class TestValidateUltimoDiaMesLetivo:
+
+    def test_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+        assert (
+            f"O último dia do mês ({_dia_str(ultimo)}/{mes:02d}) é letivo"
+            in result[0]["erro"]
+        )
+
+    def test_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_ultimo_dia_nao_letivo(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=False,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_ultimo_dia_sem_calendario(
+        self,
+        solicitacao_medicao_inicial_factory,
+        periodo_escolar_factory,
+        escola,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            None,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=None,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_emei_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_emei,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_emei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_emei_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_emei,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_emei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_cemei_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cemei,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cemei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_cemei_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cemei,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cemei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_cei_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cei,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_cei_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cei,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_ceu_gestao_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_ceu_gestao,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_ceu_gestao,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_ceu_gestao_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_ceu_gestao,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_ceu_gestao,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_emebs_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_emebs,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_emebs,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_emebs_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_emebs,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_emebs,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_multiplos_periodos_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        periodo_manha = periodo_escolar_factory.create(nome="MANHA")
+        periodo_tarde = periodo_escolar_factory.create(nome="TARDE")
+        categoria = CategoriaMedicao.objects.create(nome="ALIMENTAÇÃO")
+        for periodo in [periodo_manha, periodo_tarde]:
+            medicao = Medicao.objects.create(
+                solicitacao_medicao_inicial=solicitacao,
+                periodo_escolar=periodo,
+            )
+            ValorMedicao.objects.create(
+                medicao=medicao,
+                categoria_medicao=categoria,
+                dia="01",
+                nome_campo="lanche",
+                valor="10",
+            )
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 2
+        for erro in result:
+            assert (
+                f"O último dia do mês ({_dia_str(ultimo)}/{mes:02d}) é letivo"
+                in erro["erro"]
+            )
+
+    def test_ultimo_dia_fim_de_semana_nao_valida(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola,
+    ):
+        mes, ano = 5, 2025
+        ultimo = 31
+        assert datetime.date(ano, mes, ultimo).weekday() >= 5
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_ultimo_dia_letivo_com_campo_auto_criado_apenas(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        periodo = periodo_escolar_factory.create(nome="MANHA")
+        medicao = Medicao.objects.create(
+            solicitacao_medicao_inicial=solicitacao,
+            periodo_escolar=periodo,
+        )
+        categoria = CategoriaMedicao.objects.create(nome="ALIMENTAÇÃO")
+        ValorMedicao.objects.create(
+            medicao=medicao,
+            categoria_medicao=categoria,
+            dia=_dia_str(_ultimo_dia(mes, ano)),
+            nome_campo="matriculados",
+            valor="0",
+        )
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_exclui_medicoes_de_grupo(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        grupo_programas_e_projetos,
+        grupo_etec,
+        grupo_solicitacoes_alimentacao,
+        escola,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        categoria = CategoriaMedicao.objects.create(nome="ALIMENTAÇÃO")
+        periodo = periodo_escolar_factory.create(nome="MANHA")
+        medicao_manha = Medicao.objects.create(
+            solicitacao_medicao_inicial=solicitacao,
+            periodo_escolar=periodo,
+        )
+        ValorMedicao.objects.create(
+            medicao=medicao_manha,
+            categoria_medicao=categoria,
+            dia=_dia_str(ultimo),
+            nome_campo="lanche",
+            valor="10",
+        )
+        for grupo in [
+            grupo_programas_e_projetos,
+            grupo_etec,
+            grupo_solicitacoes_alimentacao,
+        ]:
+            Medicao.objects.create(
+                solicitacao_medicao_inicial=solicitacao,
+                grupo=grupo,
+            )
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_cieja_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cieja,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cieja,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_cieja_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cieja,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cieja,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_cmct_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cmct,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cmct,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_cmct_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cmct,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cmct,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_ceu_cemei_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_ceu_cemei,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_ceu_cemei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_ceu_cemei_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_ceu_cemei,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_ceu_cemei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_ceu_emei_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_ceu_emei,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_ceu_emei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_ceu_emei_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_ceu_emei,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_ceu_emei,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0
+
+    def test_cci_ultimo_dia_letivo_sem_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cci,
+    ):
+        mes, ano = _get_mes_ano()
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cci,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=None)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 1
+
+    def test_cci_ultimo_dia_letivo_com_preenchimento(
+        self,
+        solicitacao_medicao_inicial_factory,
+        dia_calendario_factory,
+        periodo_escolar_factory,
+        escola_cci,
+    ):
+        mes, ano = _get_mes_ano()
+        ultimo = _ultimo_dia(mes, ano)
+        solicitacao = _setup_solicitacao(
+            solicitacao_medicao_inicial_factory,
+            dia_calendario_factory,
+            escola_cci,
+            mes,
+            ano,
+            ultimo_dia_eh_letivo=True,
+        )
+        _cria_medicao_e_valores(solicitacao, periodo_escolar_factory, dia=ultimo)
+        lista_erros = []
+
+        result = validate_ultimo_dia_mes_letivo(solicitacao, lista_erros)
+
+        assert len(result) == 0

--- a/src/medicao_inicial/api/serializers_create.py
+++ b/src/medicao_inicial/api/serializers_create.py
@@ -107,6 +107,7 @@ from ..validators import (
     validate_solicitacoes_programas_e_projetos,
     validate_solicitacoes_programas_e_projetos_emebs,
     validate_solicitacoes_programas_e_projetos_escola_sem_alunos_regulares,
+    validate_ultimo_dia_mes_letivo,
 )
 
 
@@ -425,6 +426,21 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
             instance, lista_erros
         )
         lista_erros = validate_lanches_emergenciais_diarios(instance, lista_erros)
+
+        if lista_erros:
+            raise serializers.ValidationError(lista_erros)
+
+    def valida_finalizar_medicao_ultimo_dia_mes(
+        self, instance: SolicitacaoMedicaoInicial
+    ) -> None:
+        if (
+            instance.status
+            != SolicitacaoMedicaoInicial.workflow_class.MEDICAO_EM_ABERTO_PARA_PREENCHIMENTO_UE
+        ):
+            return
+
+        lista_erros = []
+        lista_erros = validate_ultimo_dia_mes_letivo(instance, lista_erros)
 
         if lista_erros:
             raise serializers.ValidationError(lista_erros)
@@ -1109,6 +1125,7 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         ):
             self.cria_valores_medicao_logs_emef_emei(instance)
             self.cria_valores_medicao_logs_cei(instance)
+            self.valida_finalizar_medicao_ultimo_dia_mes(instance)
             self.valida_finalizar_medicao_emef_emei(instance)
             self.valida_finalizar_medicao_cemei(instance)
             self.valida_finalizar_medicao_cei(instance)

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -95,6 +95,9 @@ EXCLUIR_MEDICOES = ["ETEC", "Programas e Projetos", "Solicitações de Alimenta�
 def validate_ultimo_dia_mes_letivo(
     instance: SolicitacaoMedicaoInicial, lista_erros: list
 ) -> list:
+    if not instance.escola.possui_alunos_regulares:
+        return lista_erros
+
     mes = int(instance.mes)
     ano = int(instance.ano)
     ultimo_dia = calendar.monthrange(ano, mes)[1]

--- a/src/medicao_inicial/validators.py
+++ b/src/medicao_inicial/validators.py
@@ -89,6 +89,43 @@ def erros_unicos(lista_erros):
     return list(map(dict, set(tuple(sorted(erro.items())) for erro in lista_erros)))
 
 
+EXCLUIR_MEDICOES = ["ETEC", "Programas e Projetos", "Solicitações de Alimentação"]
+
+
+def validate_ultimo_dia_mes_letivo(
+    instance: SolicitacaoMedicaoInicial, lista_erros: list
+) -> list:
+    mes = int(instance.mes)
+    ano = int(instance.ano)
+    ultimo_dia = calendar.monthrange(ano, mes)[1]
+
+    dias_letivos_calendario = DiaCalendario.objects.filter(
+        data__month=mes, data__year=ano, escola=instance.escola, dia_letivo=True
+    )
+    dias_letivos_list = list(
+        set(dias_letivos_calendario.values_list("data__day", flat=True))
+    )
+    dias_letivos_uteis = filtrar_dias_letivos(dias_letivos_list, mes, ano)
+
+    if ultimo_dia not in dias_letivos_uteis:
+        return lista_erros
+
+    dia_str = f"{ultimo_dia:02d}"
+    for medicao in instance.medicoes.exclude(grupo__nome__in=EXCLUIR_MEDICOES):
+        tem_valor = (
+            medicao.valores_medicao.filter(dia=dia_str).exclude(valor=None).exists()
+        )
+        if not tem_valor:
+            lista_erros.append(
+                {
+                    "periodo_escolar": medicao.nome_periodo_grupo,
+                    "erro": f"O último dia do mês ({dia_str}/{mes:02d}) é letivo e não foi preenchido.",
+                }
+            )
+
+    return erros_unicos(lista_erros)
+
+
 def buscar_valores_lancamento_alimentacoes(
     linhas_da_tabela,
     solicitacao,


### PR DESCRIPTION
# Este PR:
- nao permite que a escola finalize a medição sem os dados do ultimo dia letivo preenchido
- implementa testes unitários para a validação

### Referência azure:
- [AB#152528](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152528)