### PR TITLE
Feature/150575 envia email apos aprovacao ficha

### DIFF
--- a/src/dados_comuns/fluxo_status.py
+++ b/src/dados_comuns/fluxo_status.py
@@ -5971,9 +5971,40 @@ class FluxoFichaTecnicaDoProduto(xwf_models.WorkflowEnabled, models.Model):
     def _gpcodae_aprova_hook(self, *args, **kwargs):
         user = kwargs["user"]
         if user:
-            self.salvar_log_transicao(
+            log_transicao =self.salvar_log_transicao(
                 status_evento=LogSolicitacoesUsuario.FICHA_TECNICA_APROVADA,
                 usuario=user,
+            )
+
+            empresa = self.empresa
+            nome_fornecedor = (
+                f"{empresa.nome_fantasia} - {empresa.razao_social}" if empresa else "-"
+            )
+            numero_ficha_tecnica = self.numero
+            nome_produto = self.produto.nome if self.produto else "-"
+            data_envio = log_transicao.criado_em.strftime("%d/%m/%Y")
+
+            url_detalhes_ficha_tecnica = (
+                f"{base_url}/pre-recebimento/detalhar-ficha-tecnica?uuid={self.uuid}"
+            )
+
+            contexto = {
+                "nome_fornecedor": nome_fornecedor,
+                "numero_ficha_tecnica": numero_ficha_tecnica,
+                "nome_produto": nome_produto,
+                "pregao_chamada_publica": self.pregao_chamada_publica,
+                "data_envio": data_envio,
+                "url_detalhes_ficha_tecnica": url_detalhes_ficha_tecnica,
+            }
+
+            EmailENotificacaoService.enviar_email(
+                titulo=f"Ficha Técnica Aprovada - ({numero_ficha_tecnica})",
+                assunto=f"[SIGPAE] Ficha Técnica Aprovada - ({numero_ficha_tecnica})",
+                template="pre_recebimento_email_codae_aprova_ficha_tecnica.html",
+                contexto_template=contexto,
+                destinatarios=PartesInteressadasService.usuarios_vinculados_a_empresa_do_objeto(
+                    self, somente_email=True
+                ),
             )
 
     @xworkflows.after_transition("gpcodae_envia_para_correcao")

--- a/src/dados_comuns/fluxo_status.py
+++ b/src/dados_comuns/fluxo_status.py
@@ -5971,11 +5971,12 @@ class FluxoFichaTecnicaDoProduto(xwf_models.WorkflowEnabled, models.Model):
     def _gpcodae_aprova_hook(self, *args, **kwargs):
         user = kwargs["user"]
         if user:
-            log_transicao =self.salvar_log_transicao(
+            log_transicao = self.salvar_log_transicao(
                 status_evento=LogSolicitacoesUsuario.FICHA_TECNICA_APROVADA,
                 usuario=user,
             )
 
+            # Envio de email
             empresa = self.empresa
             nome_fornecedor = (
                 f"{empresa.nome_fantasia} - {empresa.razao_social}" if empresa else "-"

--- a/src/dados_comuns/templates/pre_recebimento_email_codae_aprova_ficha_tecnica.html
+++ b/src/dados_comuns/templates/pre_recebimento_email_codae_aprova_ficha_tecnica.html
@@ -1,0 +1,25 @@
+{% extends 'email_base.html' %}
+{% load email_templatetags %}
+
+{% block conteudo %}
+  <p>Olá!</p>
+
+  <p>A <strong>CODAE</strong> aprovou a <strong>Ficha Técnica ({{ numero_ficha_tecnica }})</strong> referente ao produto <strong>{{ nome_produto }}</strong>.</p>
+
+  <br/>
+
+  <div style="text-align: left;">
+    <strong>Nº do Pregão/Chamada Pública:</strong> {{ pregao_chamada_publica }}<br/>
+    <strong>Data do Envio:</strong> {{ data_envio }}
+  </div>
+
+  <br/><br/>
+
+  <p>Para visualizar os detalhes da Ficha Técnica e dar andamento à análise, acesse o sistema por meio do link abaixo:</p>
+
+  <p><a href="{{ url_detalhes_ficha_tecnica }}">Clique aqui para acessar os detalhes da Ficha Técnica</a></p>
+
+  <br/>
+
+  <p><em>Este é um e-mail automático. Não é necessário respondê-lo.</em></p>
+{% endblock %}

--- a/src/pre_recebimento/__tests__/test_workflow.py
+++ b/src/pre_recebimento/__tests__/test_workflow.py
@@ -7,6 +7,7 @@ from src.dados_comuns.constants import (
     COORDENADOR_GESTAO_PRODUTO,
 )
 from src.dados_comuns.models import LogSolicitacoesUsuario, Notificacao
+from src.pre_recebimento.ficha_tecnica.models import FichaTecnicaDoProduto
 
 pytestmark = pytest.mark.django_db
 
@@ -269,6 +270,61 @@ def test_ficha_tecnica_deve_enviar_email_ao_iniciar_fluxo(
     )
     assert email_coordenador in kwargs["destinatarios"]
     assert email_admin in kwargs["destinatarios"]
+
+    contexto = kwargs["contexto_template"]
+
+    nome_fornecedor_esperado = (
+        f"{ficha.empresa.nome_fantasia} - {ficha.empresa.razao_social}"
+    )
+    assert contexto["nome_fornecedor"] == nome_fornecedor_esperado
+    assert contexto["numero_ficha_tecnica"] == ficha.numero
+    assert contexto["nome_produto"] == ficha.produto.nome
+    assert "data_envio" in contexto
+    assert (
+        f"/pre-recebimento/detalhar-ficha-tecnica?uuid={ficha.uuid}"
+        in contexto["url_detalhes_ficha_tecnica"]
+    )
+
+
+@patch(
+    "src.dados_comuns.fluxo_status.PartesInteressadasService."
+    "usuarios_vinculados_a_empresa_do_objeto"
+)
+@patch("src.dados_comuns.fluxo_status.EmailENotificacaoService.enviar_email")
+def test_ficha_tecnica_deve_enviar_email_ao_aprovar(
+    mock_enviar_email,
+    mock_usuarios_vinculados,
+    ficha_tecnica_factory,
+    django_user_model,
+):
+    email_fornecedor = "fornecedor@test.com"
+    mock_usuarios_vinculados.return_value = [email_fornecedor]
+
+    usuario = django_user_model.objects.create_user(
+        username="codae@test.com",
+        password="123",
+        email="codae@test.com",
+        registro_funcional="7654321",
+    )
+
+    ficha = ficha_tecnica_factory(
+        status=FichaTecnicaDoProduto.workflow_class.ENVIADA_PARA_ANALISE
+    )
+
+    ficha.gpcodae_aprova(user=usuario)
+
+    mock_enviar_email.assert_called_once()
+
+    _, kwargs = mock_enviar_email.call_args
+
+    assert kwargs["titulo"] == f"Ficha Técnica Aprovada - ({ficha.numero})"
+    assert (
+        kwargs["assunto"] == f"[SIGPAE] Ficha Técnica Aprovada - ({ficha.numero})"
+    )
+    assert (
+        kwargs["template"] == "pre_recebimento_email_codae_aprova_ficha_tecnica.html"
+    )
+    assert email_fornecedor in kwargs["destinatarios"]
 
     contexto = kwargs["contexto_template"]
 

--- a/src/pre_recebimento/__tests__/test_workflow.py
+++ b/src/pre_recebimento/__tests__/test_workflow.py
@@ -317,13 +317,10 @@ def test_ficha_tecnica_deve_enviar_email_ao_aprovar(
 
     _, kwargs = mock_enviar_email.call_args
 
+    # Valida conteúdo do email
     assert kwargs["titulo"] == f"Ficha Técnica Aprovada - ({ficha.numero})"
-    assert (
-        kwargs["assunto"] == f"[SIGPAE] Ficha Técnica Aprovada - ({ficha.numero})"
-    )
-    assert (
-        kwargs["template"] == "pre_recebimento_email_codae_aprova_ficha_tecnica.html"
-    )
+    assert kwargs["assunto"] == f"[SIGPAE] Ficha Técnica Aprovada - ({ficha.numero})"
+    assert kwargs["template"] == "pre_recebimento_email_codae_aprova_ficha_tecnica.html"
     assert email_fornecedor in kwargs["destinatarios"]
 
     contexto = kwargs["contexto_template"]


### PR DESCRIPTION
# Este PR

 - Implementa o envio automático de email quando ficha técnica for aprovada;
 - Adiciona teste unitário para validar o email enviado.

### Referência Azure

 - [AB#150575](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/150575)