### PR TITLE
Feature/150565 envio email fornecedor corrige ficha

### DIFF
--- a/src/dados_comuns/fluxo_status.py
+++ b/src/dados_comuns/fluxo_status.py
@@ -5976,11 +5976,6 @@ class FluxoFichaTecnicaDoProduto(xwf_models.WorkflowEnabled, models.Model):
                 usuario=user,
             )
 
-            # Envio de email
-            empresa = self.empresa
-            nome_fornecedor = (
-                f"{empresa.nome_fantasia} - {empresa.razao_social}" if empresa else "-"
-            )
             numero_ficha_tecnica = self.numero
             nome_produto = self.produto.nome if self.produto else "-"
             data_envio = log_transicao.criado_em.strftime("%d/%m/%Y")
@@ -5990,7 +5985,6 @@ class FluxoFichaTecnicaDoProduto(xwf_models.WorkflowEnabled, models.Model):
             )
 
             contexto = {
-                "nome_fornecedor": nome_fornecedor,
                 "numero_ficha_tecnica": numero_ficha_tecnica,
                 "nome_produto": nome_produto,
                 "pregao_chamada_publica": self.pregao_chamada_publica,
@@ -6017,6 +6011,41 @@ class FluxoFichaTecnicaDoProduto(xwf_models.WorkflowEnabled, models.Model):
                 usuario=user,
             )
 
+            numero_ficha_tecnica = self.numero
+            nome_produto = self.produto.nome if self.produto else "-"
+            data_envio = log_transicao.criado_em.strftime("%d/%m/%Y")
+
+            url_detalhes_ficha_tecnica = (
+                f"{base_url}/pre-recebimento/detalhar-ficha-tecnica?uuid={self.uuid}"
+            )
+
+            contexto = {
+                "numero_ficha_tecnica": numero_ficha_tecnica,
+                "nome_produto": nome_produto,
+                "pregao_chamada_publica": self.pregao_chamada_publica,
+                "data_envio": data_envio,
+                "url_detalhes_ficha_tecnica": url_detalhes_ficha_tecnica,
+            }
+
+            EmailENotificacaoService.enviar_email(
+                titulo=f"Correção solicitada na Ficha Técnica - ({numero_ficha_tecnica})",
+                assunto=f"[SIGPAE] Correção solicitada na Ficha Técnica - ({numero_ficha_tecnica})",
+                template="pre_recebimento_email_codae_solicita_correcao_ficha_tecnica.html",
+                contexto_template=contexto,
+                destinatarios=PartesInteressadasService.usuarios_vinculados_a_empresa_do_objeto(
+                    self, somente_email=True
+                ),
+            )
+
+    @xworkflows.after_transition("fornecedor_corrige")
+    def _fornecedor_corrige_hook(self, *args, **kwargs):
+        user = kwargs["user"]
+        if user:
+            log_transicao = self.salvar_log_transicao(
+                status_evento=LogSolicitacoesUsuario.FICHA_TECNICA_ENVIADA_PARA_ANALISE,
+                usuario=user,
+            )
+
             empresa = self.empresa
             nome_fornecedor = (
                 f"{empresa.nome_fantasia} - {empresa.razao_social}" if empresa else "-"
@@ -6039,22 +6068,17 @@ class FluxoFichaTecnicaDoProduto(xwf_models.WorkflowEnabled, models.Model):
             }
 
             EmailENotificacaoService.enviar_email(
-                titulo=f"Correção solicitada na Ficha Técnica - ({numero_ficha_tecnica})",
-                assunto=f"[SIGPAE] Correção solicitada na Ficha Técnica - ({numero_ficha_tecnica})",
-                template="pre_recebimento_email_codae_solicita_correcao_ficha_tecnica.html",
+                titulo=f"Ficha Técnica corrigida pelo fornecedor - ({numero_ficha_tecnica})",
+                assunto=f"Ficha Técnica corrigida pelo fornecedor - ({numero_ficha_tecnica})",
+                template="pre_recebimento_email_fornecedor_corrige_ficha_tecnica.html",
                 contexto_template=contexto,
-                destinatarios=PartesInteressadasService.usuarios_vinculados_a_empresa_do_objeto(
-                    self, somente_email=True
+                destinatarios=PartesInteressadasService.usuarios_por_perfis(
+                    nomes_perfis=[
+                        constants.COORDENADOR_GESTAO_PRODUTO,
+                        constants.ADMINISTRADOR_GESTAO_PRODUTO,
+                    ],
+                    somente_email=True,
                 ),
-            )
-
-    @xworkflows.after_transition("fornecedor_corrige")
-    def _fornecedor_corrige_hook(self, *args, **kwargs):
-        user = kwargs["user"]
-        if user:
-            self.salvar_log_transicao(
-                status_evento=LogSolicitacoesUsuario.FICHA_TECNICA_ENVIADA_PARA_ANALISE,
-                usuario=user,
             )
 
     @xworkflows.after_transition("fornecedor_atualiza")

--- a/src/dados_comuns/templates/pre_recebimento_email_fornecedor_corrige_ficha_tecnica.html
+++ b/src/dados_comuns/templates/pre_recebimento_email_fornecedor_corrige_ficha_tecnica.html
@@ -1,0 +1,25 @@
+{% extends 'email_base.html' %}
+{% load email_templatetags %}
+
+{% block conteudo %}
+  <p>Olá!</p>
+
+  <p><strong>{{ nome_fornecedor }}</strong> corrigiu a Ficha Técnica <strong>({{ numero_ficha_tecnica }})</strong> referente ao produto <strong>{{ nome_produto }}</strong>.</p>
+
+  <br/>
+
+  <div style="text-align: left;">
+    <strong>Nº do Pregão/Chamada Pública:</strong> {{ pregao_chamada_publica }}<br/>
+    <strong>Data do Envio:</strong> {{ data_envio }}
+  </div>
+
+  <br/><br/>
+
+  <p>Para visualizar os detalhes da solicitação de correção e realizar os ajustes necessários, acesse o sistema por meio do link abaixo:</p>
+
+  <p><a href="{{ url_detalhes_ficha_tecnica }}">Clique aqui para acessar os detalhes da Ficha Técnica</a></p>
+
+  <br/>
+
+  <p><em>Este é um e-mail automático. Não é necessário respondê-lo.</em></p>
+{% endblock %}

--- a/src/pre_recebimento/__tests__/test_workflow.py
+++ b/src/pre_recebimento/__tests__/test_workflow.py
@@ -325,10 +325,6 @@ def test_ficha_tecnica_deve_enviar_email_ao_aprovar(
 
     contexto = kwargs["contexto_template"]
 
-    nome_fornecedor_esperado = (
-        f"{ficha.empresa.nome_fantasia} - {ficha.empresa.razao_social}"
-    )
-    assert contexto["nome_fornecedor"] == nome_fornecedor_esperado
     assert contexto["numero_ficha_tecnica"] == ficha.numero
     assert contexto["nome_produto"] == ficha.produto.nome
     assert "data_envio" in contexto
@@ -381,6 +377,49 @@ def test_ficha_tecnica_deve_enviar_email_ao_solicitar_correcao(
         == "pre_recebimento_email_codae_solicita_correcao_ficha_tecnica.html"
     )
     assert email_fornecedor in kwargs["destinatarios"]
+
+
+@patch("src.dados_comuns.fluxo_status.PartesInteressadasService.usuarios_por_perfis")
+@patch("src.dados_comuns.fluxo_status.EmailENotificacaoService.enviar_email")
+def test_deve_enviar_email_quando_fornecedor_corrigir_ficha_tecnica(
+    mock_enviar_email,
+    mock_usuarios_por_perfis,
+    ficha_tecnica_factory,
+    django_user_model,
+):
+    email_coordenador = "coordenador@test.com"
+    email_admin = "admin@test.com"
+    mock_usuarios_por_perfis.return_value = [email_coordenador, email_admin]
+
+    usuario = django_user_model.objects.create_user(
+        username="fornecedor@test.com",
+        password="123",
+        email="fornecedor@test.com",
+        registro_funcional="1234567",
+    )
+
+    ficha = ficha_tecnica_factory(
+        status=FichaTecnicaDoProduto.workflow_class.ENVIADA_PARA_CORRECAO
+    )
+
+    ficha.fornecedor_corrige(user=usuario)
+
+    mock_enviar_email.assert_called_once()
+
+    _, kwargs = mock_enviar_email.call_args
+
+    assert (
+        kwargs["titulo"] == f"Ficha Técnica corrigida pelo fornecedor - ({ficha.numero})"
+    )
+    assert (
+        kwargs["assunto"]
+        == f"Ficha Técnica corrigida pelo fornecedor - ({ficha.numero})"
+    )
+    assert (
+        kwargs["template"] == "pre_recebimento_email_fornecedor_corrige_ficha_tecnica.html"
+    )
+    assert email_coordenador in kwargs["destinatarios"]
+    assert email_admin in kwargs["destinatarios"]
 
 
 @patch("src.dados_comuns.fluxo_status.PartesInteressadasService.usuarios_por_perfis")


### PR DESCRIPTION
# Este PR

 - Implementa envio de email quando Fornecedor corrige Ficha Técnica;
 - Adiciona teste unitário para validar o envio do email.

### Referência Azure

 - [AB#150565](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/150565)