### PR TITLE
fix(153370): :bug: corrige task para criar logs de dietas do último dia do recreio nas ferias

### DIFF
--- a/src/dieta_especial/tasks/logs.py
+++ b/src/dieta_especial/tasks/logs.py
@@ -128,13 +128,19 @@ def gera_logs_dietas_recreio_ferias_diariamente():
             tipo_solicitacao__in=["COMUM", "ALTERACAO_UE"],
             motivo_alteracao_ue__nome="Dieta Especial - Recreio nas Férias",
             ativo=True,
-            status=SolicitacaoDietaEspecial.workflow_class.CODAE_AUTORIZADO,
+            status__in=[
+                SolicitacaoDietaEspecial.workflow_class.CODAE_AUTORIZADO,
+                "TERMINADA_AUTOMATICAMENTE_SISTEMA"
+            ]
         )
         | Q(
             tipo_solicitacao="ALUNO_NAO_MATRICULADO",
             ativo=True,
             dieta_para_recreio_ferias=True,
-            status=SolicitacaoDietaEspecial.workflow_class.CODAE_AUTORIZADO,
+            status__in=[
+                SolicitacaoDietaEspecial.workflow_class.CODAE_AUTORIZADO,
+                "TERMINADA_AUTOMATICAMENTE_SISTEMA"
+            ]
         )
     )
 


### PR DESCRIPTION
# Este PR

 - Corrige task de criação de logs de dietas para o Recreio nas Férias;
 - Lógica anterior não contemplava as dietas do último dia do recreio (pois a solicitação muda de status).
