### PR TITLE
Automação para a rota de Conferência da Guia c/ ocorrência

### DIFF
--- a/tests/cypress/e2e/api/validar_conferencia_da_guia_com_ocorrencia.cy.js
+++ b/tests/cypress/e2e/api/validar_conferencia_da_guia_com_ocorrencia.cy.js
@@ -1,5 +1,12 @@
 /// <reference types='cypress' />
 
+function normalizarEnum(valor) {
+	return String(valor)
+		.normalize('NFD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.toUpperCase()
+}
+
 describe('Validar conferência da guia com ocorrência da aplicação SIGPAE', () => {
 	const usuario = Cypress.env('usuario_abastecimento')
 	const senha = Cypress.env('senha')
@@ -34,6 +41,93 @@ describe('Validar conferência da guia com ocorrência da aplicação SIGPAE', (
 						.that.is.an('array')
 				})
 			})
+		})
+	})
+
+	context('Rota GET api/conferencia-da-guia-com-ocorrencia/{uuid}/', () => {
+		it('Valida a consulta por UUID com sucesso', () => {
+			cy.consultar_conferencia_da_guia_com_ocorrencia('limit=1&offset=0').then(
+				(responseLista) => {
+					expect(responseLista.status).to.eq(200)
+					expect(responseLista.body.results).to.be.an('array').and.not.to.be.empty
+
+					const uuid = responseLista.body.results[0].uuid
+					expect(uuid).to.be.a('string').and.not.to.be.empty
+
+					cy.consultar_conferencia_da_guia_com_ocorrencia_por_uuid(uuid).then(
+						(response) => {
+							expect(response.status).to.eq(200)
+							expect(response.body).to.include({ uuid })
+							expect(response.body).to.include.all.keys(
+								'criado_por',
+								'conferencia_dos_alimentos',
+								'guia',
+								'data_recebimento',
+								'hora_recebimento',
+								'nome_motorista',
+								'placa_veiculo',
+								'eh_reposicao',
+							)
+							expect(response.body.conferencia_dos_alimentos).to.be.an('array')
+						},
+					)
+				},
+			)
+		})
+	})
+
+	context('Rota POST api/conferencia-da-guia-com-ocorrencia/', () => {
+		it('Cadastra conferência da guia com ocorrência com sucesso', () => {
+			cy.consultar_conferencia_da_guia_com_ocorrencia('limit=10&offset=0').then(
+				(responseLista) => {
+					expect(responseLista.status).to.eq(200)
+					expect(responseLista.body.results).to.be.an('array').and.not.to.be.empty
+
+					const conferencia = responseLista.body.results.find((item) =>
+						item.conferencia_dos_alimentos.some(
+							(itemAlimento) => itemAlimento.tem_ocorrencia,
+						),
+					)
+					expect(conferencia).to.exist
+
+					const alimento = conferencia.conferencia_dos_alimentos.find(
+						(itemAlimento) => itemAlimento.tem_ocorrencia,
+					)
+					const agora = new Date()
+					const dados_teste = {
+						conferencia_dos_alimentos: [
+							{
+								conferencia: conferencia.uuid,
+								tipo_embalagem: normalizarEnum(alimento.tipo_embalagem),
+								nome_alimento: alimento.nome_alimento,
+								qtd_recebido: alimento.qtd_recebido,
+								status_alimento: normalizarEnum(alimento.status_alimento),
+								ocorrencia: alimento.ocorrencia,
+								observacao: 'Cadastro criado pelo teste automatizado',
+								tem_ocorrencia: alimento.tem_ocorrencia,
+							},
+						],
+						guia: conferencia.guia.uuid,
+						nome_motorista: `Motorista teste ${agora.getTime()}`,
+						placa_veiculo: 'TES1A23',
+						data_recebimento: agora.toISOString().slice(0, 10),
+						hora_recebimento: agora.toTimeString().slice(0, 8),
+						eh_reposicao: false,
+					}
+
+					cy.cadastrar_conferencia_da_guia_com_ocorrencia(dados_teste).then(
+						(response) => {
+							expect(response.status, JSON.stringify(response.body)).to.eq(201)
+							expect(response.body).to.include({
+								nome_motorista: dados_teste.nome_motorista,
+								placa_veiculo: dados_teste.placa_veiculo,
+								eh_reposicao: dados_teste.eh_reposicao,
+							})
+							expect(response.body.uuid).to.be.a('string').and.not.to.be.empty
+						},
+					)
+				},
+			)
 		})
 	})
 })

--- a/tests/cypress/support/commands_api/commands_conferencia_da_guia_com_ocorrencia.js
+++ b/tests/cypress/support/commands_api/commands_conferencia_da_guia_com_ocorrencia.js
@@ -16,3 +16,67 @@ Cypress.Commands.add(
 		})
 	},
 )
+
+Cypress.Commands.add(
+	'consultar_conferencia_da_guia_com_ocorrencia_por_uuid',
+	(uuid) => {
+		return cy.request({
+			method: 'GET',
+			url:
+				Cypress.config('baseUrl') +
+				`api/conferencia-da-guia-com-ocorrencia/${uuid}/`,
+			timeout: 60000,
+			headers: {
+				Authorization: 'JWT ' + globalThis.token,
+			},
+			failOnStatusCode: false,
+		})
+	},
+)
+
+Cypress.Commands.add(
+	'cadastrar_conferencia_da_guia_com_ocorrencia',
+	(dados_teste) => {
+		const conferenciaDosAlimentos = dados_teste.conferencia_dos_alimentos.map(
+			(alimento) => {
+				const alimentoDaConferencia = {
+					conferencia: alimento.conferencia,
+					tipo_embalagem: alimento.tipo_embalagem,
+					nome_alimento: alimento.nome_alimento,
+					qtd_recebido: alimento.qtd_recebido,
+					status_alimento: alimento.status_alimento,
+					ocorrencia: alimento.ocorrencia,
+					observacao: alimento.observacao,
+					tem_ocorrencia: alimento.tem_ocorrencia,
+				}
+
+				if (alimento.arquivo) {
+					alimentoDaConferencia.arquivo = alimento.arquivo
+				}
+
+				return alimentoDaConferencia
+			},
+		)
+
+		return cy.request({
+			method: 'POST',
+			url:
+				Cypress.config('baseUrl') +
+				'api/conferencia-da-guia-com-ocorrencia/',
+			timeout: 60000,
+			headers: {
+				Authorization: 'JWT ' + globalThis.token,
+			},
+			body: {
+				conferencia_dos_alimentos: conferenciaDosAlimentos,
+				guia: dados_teste.guia,
+				nome_motorista: dados_teste.nome_motorista,
+				placa_veiculo: dados_teste.placa_veiculo,
+				data_recebimento: dados_teste.data_recebimento,
+				hora_recebimento: dados_teste.hora_recebimento,
+				eh_reposicao: dados_teste.eh_reposicao,
+			},
+			failOnStatusCode: false,
+		})
+	},
+)


### PR DESCRIPTION
Implementada a automação Cypress para a rota de Conferência da Guia com Ocorrência.
Adicionado teste para listagem paginada via GET.
Adicionado teste de consulta individual via GET /{uuid}/.
Adicionado comando e cenário para cadastro via POST.
Incluídas validações de status, estrutura da resposta, UUID e dados principais.
Ajustado o POST para não enviar criado_por e enviar arquivo apenas quando existir um arquivo válido.
Normalizados os campos tipo_embalagem e status_alimento para o formato aceito pela API.