### PR TITLE
Feature/152191 pre recebimento permitir inclusao de justificativa na aprovacao de alteracao de cronograma

### DIFF
--- a/src/pre_recebimento/__tests__/test_urls.py
+++ b/src/pre_recebimento/__tests__/test_urls.py
@@ -396,6 +396,45 @@ def test_url_perfil_dilog_abastecimento_cronograma(
     assert obj.status == "APROVADO_DILOG_ABASTECIMENTO"
 
 
+def test_url_perfil_dilog_abastecimento_aprova_com_justificativa(
+    client_autenticado_dilog_abastecimento,
+    solicitacao_cronograma_ciente,
+):
+    justificativa = "Cronograma aprovado após análise do Abastecimento"
+
+    data = json.dumps(
+        {
+            "aprovado": True,
+            "justificativa_abastecimento": justificativa,
+        }
+    )
+
+    response = client_autenticado_dilog_abastecimento.patch(
+        f"/solicitacao-de-alteracao-de-cronograma/"
+        f"{solicitacao_cronograma_ciente.uuid}/analise-abastecimento/",
+        data,
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    solicitacao = SolicitacaoAlteracaoCronograma.objects.get(
+        uuid=solicitacao_cronograma_ciente.uuid
+    )
+
+    assert solicitacao.status == "APROVADO_DILOG_ABASTECIMENTO"
+
+    log_aprovacao = LogSolicitacoesUsuario.objects.filter(
+        uuid_original=solicitacao.uuid,
+        status_evento=(
+            LogSolicitacoesUsuario
+            .APROVADO_DILOG_ABASTECIMENTO_SOLICITACAO_ALTERACAO
+        ),
+    ).first()
+
+    assert log_aprovacao is not None
+    assert log_aprovacao.justificativa == justificativa
+    
 def test_url_perfil_dilog_abastecimento_reprova_alteracao_cronograma(
     client_autenticado_dilog_abastecimento, solicitacao_cronograma_ciente
 ):

--- a/src/pre_recebimento/cronograma_entrega/api/viewsets.py
+++ b/src/pre_recebimento/cronograma_entrega/api/viewsets.py
@@ -892,13 +892,10 @@ class SolicitacaoDeAlteracaoCronogramaViewSet(viewsets.ModelViewSet):
                 uuid=uuid
             )
             if aprovado is True:
-                solicitacao_cronograma.dilog_abastecimento_aprova(user=usuario, 
-                    justificativa=justificativa)
+                solicitacao_cronograma.dilog_abastecimento_aprova(user=usuario, justificativa=justificativa)
             elif aprovado is False:
                 justificativa = request.data.get("justificativa_abastecimento")
-                solicitacao_cronograma.dilog_abastecimento_reprova(
-                    user=usuario, justificativa=justificativa
-                )
+                solicitacao_cronograma.dilog_abastecimento_reprova(user=usuario, justificativa=justificativa)
             else:
                 raise ValidationError("Parametro aprovado deve ser true ou false.")
             solicitacao_cronograma.save()

--- a/src/pre_recebimento/cronograma_entrega/api/viewsets.py
+++ b/src/pre_recebimento/cronograma_entrega/api/viewsets.py
@@ -885,12 +885,15 @@ class SolicitacaoDeAlteracaoCronogramaViewSet(viewsets.ModelViewSet):
         """
         usuario = request.user
         aprovado = request.data.get(("aprovado"), "aprovado")
+        justificativa = request.data.get("justificativa_abastecimento", "")
+
         try:
             solicitacao_cronograma = SolicitacaoAlteracaoCronograma.objects.get(
                 uuid=uuid
             )
             if aprovado is True:
-                solicitacao_cronograma.dilog_abastecimento_aprova(user=usuario)
+                solicitacao_cronograma.dilog_abastecimento_aprova(user=usuario, 
+                    justificativa=justificativa)
             elif aprovado is False:
                 justificativa = request.data.get("justificativa_abastecimento")
                 solicitacao_cronograma.dilog_abastecimento_reprova(


### PR DESCRIPTION
 ### Referência azure:
- [AB#152191](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/152191) 

Permite informar uma justificativa opcional na aprovação de alterações de cronograma pela DILOG Abastecimento, garantindo o salvamento da informação no histórico da solicitação. A justificativa continua obrigatória nos casos de reprovação e foram adicionados testes para validar o novo comportamento.
