### PR TITLE
Hotfix/adiciona-mensagem-erro-sentry

### DIFF
--- a/src/escola/__tests__/conftest.py
+++ b/src/escola/__tests__/conftest.py
@@ -561,6 +561,11 @@ def dia_calendario_nao_letivo(escola):
     )
 
 
+class MockRequest:
+    def __init__(self, url=""):
+        self.url = url
+
+
 def mocked_response(*args, **kwargs):
     class MockResponse:
         def __init__(self, json_data, status_code):
@@ -568,6 +573,7 @@ def mocked_response(*args, **kwargs):
             self.text = json_data
             self.status_code = status_code
             self.content = b"erro"
+            self.request = MockRequest()
 
         def json(self):
             return self.json_data

--- a/src/escola/services.py
+++ b/src/escola/services.py
@@ -1,4 +1,5 @@
 import requests
+import sentry_sdk
 from rest_framework import status
 
 from ..dados_comuns.constants import (
@@ -76,8 +77,25 @@ class NovoSGPServicoLogado:
     def __init__(self, login=None, senha=None):
         """Retorna um objeto para requisições no novosgp com token de acesso."""
         response = self.pegar_token_acesso(login, senha)
+
         if response.status_code != status.HTTP_200_OK:
+            with sentry_sdk.push_scope() as scope:
+                scope.set_extra("status_code", response.status_code)
+                scope.set_extra("response_body", response.text)
+                scope.set_extra("url", response.request.url)
+                scope.set_extra(
+                    "request_body",
+                    {
+                        "login": login or DJANGO_NOVO_SGP_API_LOGIN,
+                    },
+                )
+
+                sentry_sdk.capture_exception(
+                    NovoSGPServicoLogadoException("Não foi possível logar no sistema")
+                )
+
             raise NovoSGPServicoLogadoException("Não foi possível logar no sistema")
+
         self.access_token = f'Bearer {response.json()["token"]}'
 
     def pegar_foto_aluno(self, codigo_eol_aluno):


### PR DESCRIPTION
# Este PR:
- envia mensagem de erro para o sentry quando falhar o login no novosgp